### PR TITLE
Rel1 2 stable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Global excludes across all subdirectories
+*.bc
 *.o
 *.so
 regression.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ compiler: gcc
 env:
    matrix:
       - PGBRANCH=master
+      - PGBRANCH=REL_10_STABLE
       - PGBRANCH=REL9_6_STABLE
       - PGBRANCH=REL9_5_STABLE
       - PGBRANCH=REL9_4_STABLE

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ compiler: gcc
 env:
    matrix:
       - PGBRANCH=master
+      - PGBRANCH=REL_14_STABLE
       - PGBRANCH=REL_13_STABLE
       - PGBRANCH=REL_12_STABLE
       - PGBRANCH=REL_11_STABLE

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ compiler: gcc
 env:
    matrix:
       - PGBRANCH=master
+      - PGBRANCH=REL_12_STABLE
       - PGBRANCH=REL_11_STABLE
       - PGBRANCH=REL_10_STABLE
       - PGBRANCH=REL9_6_STABLE

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ compiler: gcc
 env:
    matrix:
       - PGBRANCH=master
+      - PGBRANCH=REL_11_STABLE
       - PGBRANCH=REL_10_STABLE
       - PGBRANCH=REL9_6_STABLE
       - PGBRANCH=REL9_5_STABLE

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ compiler: gcc
 env:
    matrix:
       - PGBRANCH=master
+      - PGBRANCH=REL_13_STABLE
       - PGBRANCH=REL_12_STABLE
       - PGBRANCH=REL_11_STABLE
       - PGBRANCH=REL_10_STABLE

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,15 @@ before_install:
    - CURDIR=$(pwd)
    - PGHOME=${CURDIR}/${PGBRANCH}
    - PGDATA=${PGHOME}/data
+   - PGSRC=${CURDIR}/postgres
+   - TRGMSRC=${PGSRC}/contrib/pg_trgm
    - git clone https://github.com/postgres/postgres.git
-   - cd postgres
+   - cd ${PGSRC}
    - git checkout ${PGBRANCH}
    - ./configure --prefix=${PGHOME} --enable-debug --enable-cassert
    - make -j 2
+   - make install
+   - cd ${TRGMSRC}
    - make install
    - export PATH=${PATH}:${PGHOME}/bin
    - initdb -D ${PGDATA} --locale=C --encoding=UTF8
@@ -38,6 +42,7 @@ before_script:
 
 script:
    - make USE_PGXS=1 PG_CONFIG=${PGHOME}/bin/pg_config installcheck
+   - make USE_PGXS=1 PG_CONFIG=${PGHOME}/bin/pg_config installcheck-trgm
 
 after_script:
    - if [ -f regression.diffs ]; then cat regression.diffs; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ compiler: gcc
 env:
    matrix:
       - PGBRANCH=master
+      - PGBRANCH=REL_15_STABLE
       - PGBRANCH=REL_14_STABLE
       - PGBRANCH=REL_13_STABLE
       - PGBRANCH=REL_12_STABLE

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Portions Copyright (c) 2017-2020, pg_bigm Development Group
+Portions Copyright (c) 2017-2021, pg_bigm Development Group
 
 Portions Copyright (c) 2013-2016, NTT DATA Corporation
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Portions Copyright (c) 2017-2019, pg_bigm Development Group
+Portions Copyright (c) 2017-2020, pg_bigm Development Group
 
 Portions Copyright (c) 2013-2016, NTT DATA Corporation
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Portions Copyright (c) 2017-2021, pg_bigm Development Group
+Portions Copyright (c) 2017-2022, pg_bigm Development Group
 
 Portions Copyright (c) 2013-2016, NTT DATA Corporation
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Portions Copyright (c) 2017-2022, pg_bigm Development Group
+Portions Copyright (c) 2017-2023, pg_bigm Development Group
 
 Portions Copyright (c) 2013-2016, NTT DATA Corporation
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+Portions Copyright (c) 2017-2019, pg_bigm Development Group
+
 Portions Copyright (c) 2013-2016, NTT DATA Corporation
 
 Portions Copyright (c) 1996-2012, PostgreSQL Global Development Group

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # pg_bigm
-The pg_bigm module provides full text search capability in [PostgreSQL](http://www.postgresql.org/).
+The pg_bigm module provides full text search capability in [PostgreSQL](https://www.postgresql.org/).
 This module allows a user to create **2-gram** (bigram) index for faster full text search.
 
 pg_bigm is released under the [PostgreSQL License](https://opensource.org/licenses/postgresql), a liberal Open Source license, similar to the BSD or MIT licenses.
 
-For more information look at [the official pg_bigm web site](http://pgbigm.osdn.jp/index_en.html).
+For more information look at [the official pg_bigm web site](https://pgbigm.osdn.jp/index_en.html).
 
 ## Test Status
-[![Build Status](https://travis-ci.org/MasaoFujii/pg_bigm.svg?branch=master)](https://travis-ci.org/MasaoFujii/pg_bigm)
+[![Build Status](https://travis-ci.org/pgbigm/pg_bigm.svg?branch=master)](https://travis-ci.org/pgbigm/pg_bigm)

--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ pg_bigm is released under the [PostgreSQL License](https://opensource.org/licens
 For more information look at [the official pg_bigm web site](https://pgbigm.osdn.jp/index_en.html).
 
 ## Test Status
-[![Build Status](https://travis-ci.org/pgbigm/pg_bigm.svg?branch=master)](https://travis-ci.org/pgbigm/pg_bigm)
+[![Build Status](https://travis-ci.com/pgbigm/pg_bigm.svg?branch=master)](https://travis-ci.com/github/pgbigm/pg_bigm)

--- a/bigm.h
+++ b/bigm.h
@@ -1,6 +1,6 @@
 /*-------------------------------------------------------------------------
  *
- * Portions Copyright (c) 2017-2022, pg_bigm Development Group
+ * Portions Copyright (c) 2017-2023, pg_bigm Development Group
  * Portions Copyright (c) 2013-2016, NTT DATA Corporation
  * Portions Copyright (c) 2004-2012, PostgreSQL Global Development Group
  *

--- a/bigm.h
+++ b/bigm.h
@@ -46,7 +46,25 @@ typedef struct
 
 #define BIGMSIZE	sizeof(bigm)
 
-extern inline int	bigmstrcmp(char *arg1, int len1, char *arg2, int len2);
+static inline int
+bigmstrcmp(char *arg1, int len1, char *arg2, int len2)
+{
+	int			i;
+	int			len = Min(len1, len2);
+
+	for (i = 0; i < len; i++, arg1++, arg2++)
+	{
+		if (*arg1 == *arg2)
+			continue;
+		if (*arg1 < *arg2)
+			return -1;
+		else
+			return 1;
+	}
+
+	return (len1 == len2) ? 0 : ((len1 < len2) ? -1 : 1);
+}
+
 #define CMPBIGM(a,b) ( bigmstrcmp(((bigm *)a)->str, ((bigm *)a)->bytelen, ((bigm *)b)->str, ((bigm *)b)->bytelen) )
 
 #define CPBIGM(bptr, s, len) do {		\

--- a/bigm.h
+++ b/bigm.h
@@ -1,6 +1,6 @@
 /*-------------------------------------------------------------------------
  *
- * Portions Copyright (c) 2017-2019, pg_bigm Development Group
+ * Portions Copyright (c) 2017-2020, pg_bigm Development Group
  * Portions Copyright (c) 2013-2016, NTT DATA Corporation
  * Portions Copyright (c) 2004-2012, PostgreSQL Global Development Group
  *

--- a/bigm.h
+++ b/bigm.h
@@ -1,6 +1,6 @@
 /*-------------------------------------------------------------------------
  *
- * Portions Copyright (c) 2017-2020, pg_bigm Development Group
+ * Portions Copyright (c) 2017-2021, pg_bigm Development Group
  * Portions Copyright (c) 2013-2016, NTT DATA Corporation
  * Portions Copyright (c) 2004-2012, PostgreSQL Global Development Group
  *

--- a/bigm.h
+++ b/bigm.h
@@ -1,6 +1,6 @@
 /*-------------------------------------------------------------------------
  *
- * Portions Copyright (c) 2017-2021, pg_bigm Development Group
+ * Portions Copyright (c) 2017-2022, pg_bigm Development Group
  * Portions Copyright (c) 2013-2016, NTT DATA Corporation
  * Portions Copyright (c) 2004-2012, PostgreSQL Global Development Group
  *

--- a/bigm.h
+++ b/bigm.h
@@ -1,7 +1,8 @@
 /*-------------------------------------------------------------------------
  *
- * Portions Copyright (c) 2004-2012, PostgreSQL Global Development Group
+ * Portions Copyright (c) 2017-2019, pg_bigm Development Group
  * Portions Copyright (c) 2013-2016, NTT DATA Corporation
+ * Portions Copyright (c) 2004-2012, PostgreSQL Global Development Group
  *
  * Changelog:
  *	 2013/01/09

--- a/bigm_gin.c
+++ b/bigm_gin.c
@@ -1,6 +1,6 @@
 /*-------------------------------------------------------------------------
  *
- * Portions Copyright (c) 2017-2022, pg_bigm Development Group
+ * Portions Copyright (c) 2017-2023, pg_bigm Development Group
  * Portions Copyright (c) 2013-2016, NTT DATA Corporation
  * Portions Copyright (c) 2007-2012, PostgreSQL Global Development Group
  *

--- a/bigm_gin.c
+++ b/bigm_gin.c
@@ -17,6 +17,9 @@
 #include "access/gin.h"
 #include "access/gin_private.h"
 #include "access/itup.h"
+#if PG_VERSION_NUM >= 120000
+#include "access/relation.h"
+#endif
 #include "access/skey.h"
 #include "access/tuptoaster.h"
 #include "access/xlog.h"
@@ -417,7 +420,11 @@ pg_gin_pending_stats(PG_FUNCTION_ARGS)
 	 * Construct a tuple descriptor for the result row. This must match this
 	 * function's pg_bigm--x.x.sql entry.
 	 */
+ #if PG_VERSION_NUM >= 120000
+	tupdesc = CreateTemplateTupleDesc(2);
+#else
 	tupdesc = CreateTemplateTupleDesc(2, false);
+#endif
 	TupleDescInitEntry(tupdesc, (AttrNumber) 1,
 					   "pages", INT4OID, -1, 0);
 	TupleDescInitEntry(tupdesc, (AttrNumber) 2,

--- a/bigm_gin.c
+++ b/bigm_gin.c
@@ -273,8 +273,8 @@ gin_bigm_consistent(PG_FUNCTION_ARGS)
 			 * So, independently on DIVUNION the upper bound formula is the same.
 			 */
 			res = (nkeys == 0) ? false :
-				((((((float4) ntrue) / ((float4) nkeys))) >=
-				  (float4) bigm_similarity_limit) ? true : false);
+				((((float4) ntrue) / ((float4) nkeys)) >=
+				  (float4) bigm_similarity_limit);
 			break;
 		default:
 			elog(ERROR, "unrecognized strategy number: %d", strategy);

--- a/bigm_gin.c
+++ b/bigm_gin.c
@@ -1,7 +1,8 @@
 /*-------------------------------------------------------------------------
  *
- * Portions Copyright (c) 2007-2012, PostgreSQL Global Development Group
+ * Portions Copyright (c) 2017-2019, pg_bigm Development Group
  * Portions Copyright (c) 2013-2016, NTT DATA Corporation
+ * Portions Copyright (c) 2007-2012, PostgreSQL Global Development Group
  *
  * Changelog:
  *	 2013/01/09

--- a/bigm_gin.c
+++ b/bigm_gin.c
@@ -1,6 +1,6 @@
 /*-------------------------------------------------------------------------
  *
- * Portions Copyright (c) 2017-2020, pg_bigm Development Group
+ * Portions Copyright (c) 2017-2021, pg_bigm Development Group
  * Portions Copyright (c) 2013-2016, NTT DATA Corporation
  * Portions Copyright (c) 2007-2012, PostgreSQL Global Development Group
  *

--- a/bigm_gin.c
+++ b/bigm_gin.c
@@ -1,6 +1,6 @@
 /*-------------------------------------------------------------------------
  *
- * Portions Copyright (c) 2017-2019, pg_bigm Development Group
+ * Portions Copyright (c) 2017-2020, pg_bigm Development Group
  * Portions Copyright (c) 2013-2016, NTT DATA Corporation
  * Portions Copyright (c) 2007-2012, PostgreSQL Global Development Group
  *

--- a/bigm_gin.c
+++ b/bigm_gin.c
@@ -21,7 +21,9 @@
 #include "access/relation.h"
 #endif
 #include "access/skey.h"
+#if PG_VERSION_NUM < 130000
 #include "access/tuptoaster.h"
+#endif
 #include "access/xlog.h"
 #if PG_VERSION_NUM > 90500
 #include "catalog/pg_am.h"

--- a/bigm_gin.c
+++ b/bigm_gin.c
@@ -1,6 +1,6 @@
 /*-------------------------------------------------------------------------
  *
- * Portions Copyright (c) 2017-2021, pg_bigm Development Group
+ * Portions Copyright (c) 2017-2022, pg_bigm Development Group
  * Portions Copyright (c) 2013-2016, NTT DATA Corporation
  * Portions Copyright (c) 2007-2012, PostgreSQL Global Development Group
  *

--- a/bigm_op.c
+++ b/bigm_op.c
@@ -1,6 +1,6 @@
 /*-------------------------------------------------------------------------
  *
- * Portions Copyright (c) 2017-2022, pg_bigm Development Group
+ * Portions Copyright (c) 2017-2023, pg_bigm Development Group
  * Portions Copyright (c) 2013-2016, NTT DATA Corporation
  * Portions Copyright (c) 2004-2012, PostgreSQL Global Development Group
  *

--- a/bigm_op.c
+++ b/bigm_op.c
@@ -708,25 +708,6 @@ likequery(PG_FUNCTION_ARGS)
 	PG_RETURN_TEXT_P(result);
 }
 
-inline int
-bigmstrcmp(char *arg1, int len1, char *arg2, int len2)
-{
-	int			i;
-	int			len = Min(len1, len2);
-
-	for (i = 0; i < len; i++, arg1++, arg2++)
-	{
-		if (*arg1 == *arg2)
-			continue;
-		if (*arg1 < *arg2)
-			return -1;
-		else
-			return 1;
-	}
-
-	return (len1 == len2) ? 0 : ((len1 < len2) ? -1 : 1);
-}
-
 Datum
 bigmtextcmp(PG_FUNCTION_ARGS)
 {

--- a/bigm_op.c
+++ b/bigm_op.c
@@ -1,6 +1,6 @@
 /*-------------------------------------------------------------------------
  *
- * Portions Copyright (c) 2017-2019, pg_bigm Development Group
+ * Portions Copyright (c) 2017-2020, pg_bigm Development Group
  * Portions Copyright (c) 2013-2016, NTT DATA Corporation
  * Portions Copyright (c) 2004-2012, PostgreSQL Global Development Group
  *

--- a/bigm_op.c
+++ b/bigm_op.c
@@ -1,6 +1,6 @@
 /*-------------------------------------------------------------------------
  *
- * Portions Copyright (c) 2017-2020, pg_bigm Development Group
+ * Portions Copyright (c) 2017-2021, pg_bigm Development Group
  * Portions Copyright (c) 2013-2016, NTT DATA Corporation
  * Portions Copyright (c) 2004-2012, PostgreSQL Global Development Group
  *

--- a/bigm_op.c
+++ b/bigm_op.c
@@ -1,6 +1,6 @@
 /*-------------------------------------------------------------------------
  *
- * Portions Copyright (c) 2017-2021, pg_bigm Development Group
+ * Portions Copyright (c) 2017-2022, pg_bigm Development Group
  * Portions Copyright (c) 2013-2016, NTT DATA Corporation
  * Portions Copyright (c) 2004-2012, PostgreSQL Global Development Group
  *

--- a/bigm_op.c
+++ b/bigm_op.c
@@ -25,7 +25,7 @@
 PG_MODULE_MAGIC;
 
 /* Last update date of pg_bigm */
-#define BIGM_LAST_UPDATE	"2019.10.03"
+#define BIGM_LAST_UPDATE	"2020.02.28"
 
 /* GUC variable */
 bool		bigm_enable_recheck = false;

--- a/bigm_op.c
+++ b/bigm_op.c
@@ -25,7 +25,7 @@
 PG_MODULE_MAGIC;
 
 /* Last update date of pg_bigm */
-#define BIGM_LAST_UPDATE	"2016.10.11"
+#define BIGM_LAST_UPDATE	"2019.10.03"
 
 /* GUC variable */
 bool		bigm_enable_recheck = false;

--- a/bigm_op.c
+++ b/bigm_op.c
@@ -1,7 +1,8 @@
 /*-------------------------------------------------------------------------
  *
- * Portions Copyright (c) 2004-2012, PostgreSQL Global Development Group
+ * Portions Copyright (c) 2017-2019, pg_bigm Development Group
  * Portions Copyright (c) 2013-2016, NTT DATA Corporation
+ * Portions Copyright (c) 2004-2012, PostgreSQL Global Development Group
  *
  * Changelog:
  *	 2013/01/09

--- a/expected/pg_bigm.out
+++ b/expected/pg_bigm.out
@@ -103,10 +103,13 @@ CREATE INDEX test_bigm_idx ON test_bigm
 			 USING gin (col1 gin_bigm_ops, col2 gin_bigm_ops);
 \copy test_bigm from 'data/bigm.csv' with csv
 -- tests pg_gin_pending_stats
-SELECT * FROM pg_gin_pending_stats('test_bigm_idx');
- pages | tuples 
--------+--------
-    43 |    249
+-- exclude pages column from the return values of only this call of
+-- pg_gin_pending_stats(), in order to stabilize the result of
+-- this regression test whatever block size is used in PostgreSQL server.
+SELECT tuples FROM pg_gin_pending_stats('test_bigm_idx');
+ tuples 
+--------
+    249
 (1 row)
 
 VACUUM;

--- a/expected/pg_bigm.out
+++ b/expected/pg_bigm.out
@@ -12,7 +12,7 @@ SET extra_float_digits TO 0;
 SHOW pg_bigm.last_update;
  pg_bigm.last_update 
 ---------------------
- 2016.10.11
+ 2019.10.03
 (1 row)
 
 SET pg_bigm.last_update = '2013.09.18';

--- a/expected/pg_bigm.out
+++ b/expected/pg_bigm.out
@@ -6,6 +6,8 @@ SET enable_seqscan = off;
 SET pg_bigm.enable_recheck = on;
 SET pg_bigm.gin_key_limit = 0;
 SET pg_bigm.similarity_limit = 0.02;
+-- reduce noise
+SET extra_float_digits TO 0;
 -- tests for pg_bigm.last_update
 SHOW pg_bigm.last_update;
  pg_bigm.last_update 

--- a/expected/pg_bigm.out
+++ b/expected/pg_bigm.out
@@ -12,7 +12,7 @@ SET extra_float_digits TO 0;
 SHOW pg_bigm.last_update;
  pg_bigm.last_update 
 ---------------------
- 2019.10.03
+ 2020.02.28
 (1 row)
 
 SET pg_bigm.last_update = '2013.09.18';

--- a/expected/pg_bigm_ja.out
+++ b/expected/pg_bigm_ja.out
@@ -6,6 +6,8 @@ SET enable_seqscan = off;
 SET pg_bigm.enable_recheck = on;
 SET pg_bigm.gin_key_limit = 0;
 SET pg_bigm.similarity_limit = 0.02;
+-- reduce noise
+SET extra_float_digits TO 0;
 -- tests for likequery
 SELECT likequery('ポスグレの全文検索');
       likequery       

--- a/html/index.html
+++ b/html/index.html
@@ -73,7 +73,7 @@
 <p class="padding">pg_bigmはgitでソースコードを管理しています。レポジトリは<a href="http://osdn.jp/projects/pgbigm/scm/">ここ</a>です。</p>
 
 <hr>
-<div align="right">Copyright (c) 2017-2021, pg_bigm Development Group</div>
+<div align="right">Copyright (c) 2017-2022, pg_bigm Development Group</div>
 <div align="right">Copyright (c) 2012-2016, NTT DATA Corporation</div>
 
 </body>

--- a/html/index.html
+++ b/html/index.html
@@ -23,7 +23,8 @@
 
 <h2 id="news">ニュース</h2>
 <ul>
-  <li>2019-10-03: PostgreSQL 12対応のpg_bigm 1.2最新マイナーバージョン <a href="https://osdn.net/dl/pgbigm/pg_bigm-1.2-20191003.tar.gz">pg_bigm-1.2-20191003</a> をリリースしました。 (<a href="release-1-2.html#release_note_2019-10-03">リリースノート</a>)</li>
+<li>2020-02-XX: バージョン1.1の最新マイナーバージョン <a href="https://osdn.net/dl/pgbigm/pg_bigm-1.1-202002XX.tar.gz">pg_bigm-1.1-202002XX</a>をリリースしました。(<a href="release-1-1.html#release_note_2020-02-XX">リリースノート</a>)</li>
+<li>2019-10-03: PostgreSQL 12対応のpg_bigm 1.2最新マイナーバージョン <a href="https://osdn.net/dl/pgbigm/pg_bigm-1.2-20191003.tar.gz">pg_bigm-1.2-20191003</a> をリリースしました。 (<a href="release-1-2.html#release_note_2019-10-03">リリースノート</a>)</li>
 <li>2018-11-07: pg_bigmバージョン 1.2 と 1.1 が PostgreSQL 11 に対応していることを確認しました。</li>
 <li>2017-10-06: pg_bigmバージョン 1.2 と 1.1 が PostgreSQL 10 に対応していることを確認しました。</li>
 <li>2016-10-21: PostgreSQL9.1～9.6用のpg_bigm-1.2-20161011のRPMファイルをリリースしました。RPMファイルは<a href="http://osdn.jp/projects/pgbigm/releases/66565">こちら</a>からダウンロードできます。</li>

--- a/html/index.html
+++ b/html/index.html
@@ -23,6 +23,7 @@
 
 <h2 id="news">ニュース</h2>
 <ul>
+<li>2023-02-17: RHEL 9系に対応したPostgreSQL11～15用のpg_bigm-1.2-20200228のRPMファイルをリリースしました。RPMファイルは<a href="https://osdn.net/projects/pgbigm/releases/72448">こちら</a>からダウンロードできます。</li>
 <li>2022-10-24: PostgreSQL15用のpg_bigm-1.2-20200228のRPMファイルをリリースしました。RPMファイルは<a href="https://osdn.net/projects/pgbigm/releases/72448">こちら</a>からダウンロードできます。</li>
 <li>2022-10-13: pg_bigmバージョン 1.2 が PostgreSQL 15 に対応していることを確認しました。</li>
 <li>2021-10-07: PostgreSQL14用のpg_bigm-1.2-20200228のRPMファイルをリリースしました。RPMファイルは<a href="https://osdn.net/projects/pgbigm/releases/72448">こちら</a>からダウンロードできます。</li>

--- a/html/index.html
+++ b/html/index.html
@@ -71,7 +71,7 @@
 <p class="padding">pg_bigmはgitでソースコードを管理しています。レポジトリは<a href="http://osdn.jp/projects/pgbigm/scm/">ここ</a>です。</p>
 
 <hr>
-<div align="right">Copyright (c) 2017-2020, pg_bigm Development Group</div>
+<div align="right">Copyright (c) 2017-2021, pg_bigm Development Group</div>
 <div align="right">Copyright (c) 2012-2016, NTT DATA Corporation</div>
 
 </body>

--- a/html/index.html
+++ b/html/index.html
@@ -66,7 +66,7 @@
 <p class="padding">pg_bigmはgitでソースコードを管理しています。レポジトリは<a href="http://osdn.jp/projects/pgbigm/scm/">ここ</a>です。</p>
 
 <hr>
-<div align="right">Copyright (c) 2017-2019, pg_bigm Development Group</div>
+<div align="right">Copyright (c) 2017-2020, pg_bigm Development Group</div>
 <div align="right">Copyright (c) 2012-2016, NTT DATA Corporation</div>
 
 </body>

--- a/html/index.html
+++ b/html/index.html
@@ -23,6 +23,7 @@
 
 <h2 id="news">ニュース</h2>
 <ul>
+<li>2022-10-13: pg_bigmバージョン 1.2 が PostgreSQL 15 に対応していることを確認しました。</li>
 <li>2021-10-07: PostgreSQL14用のpg_bigm-1.2-20200228のRPMファイルをリリースしました。RPMファイルは<a href="https://osdn.net/projects/pgbigm/releases/72448">こちら</a>からダウンロードできます。</li>
 <li>2021-09-30: pg_bigmバージョン 1.2 が PostgreSQL 14 に対応していることを確認しました。</li>
 <li>2020-11-17: PostgreSQL13用のpg_bigm-1.2-20200228のRPMファイルをリリースしました。RPMファイルは<a href="https://osdn.net/projects/pgbigm/releases/72448">こちら</a>からダウンロードできます。</li>

--- a/html/index.html
+++ b/html/index.html
@@ -23,6 +23,7 @@
 
 <h2 id="news">ニュース</h2>
 <ul>
+<li>2020-02-XX: バージョン1.2の最新マイナーバージョン <a href="https://osdn.net/dl/pgbigm/pg_bigm-1.2-202002XX.tar.gz">pg_bigm-1.2-202002XX</a>をリリースしました。(<a href="release-1-2.html#release_note_2020-02-XX">リリースノート</a>)</li>
 <li>2020-02-XX: バージョン1.1の最新マイナーバージョン <a href="https://osdn.net/dl/pgbigm/pg_bigm-1.1-202002XX.tar.gz">pg_bigm-1.1-202002XX</a>をリリースしました。(<a href="release-1-1.html#release_note_2020-02-XX">リリースノート</a>)</li>
 <li>2019-10-03: PostgreSQL 12対応のpg_bigm 1.2最新マイナーバージョン <a href="https://osdn.net/dl/pgbigm/pg_bigm-1.2-20191003.tar.gz">pg_bigm-1.2-20191003</a> をリリースしました。 (<a href="release-1-2.html#release_note_2019-10-03">リリースノート</a>)</li>
 <li>2018-11-07: pg_bigmバージョン 1.2 と 1.1 が PostgreSQL 11 に対応していることを確認しました。</li>

--- a/html/index.html
+++ b/html/index.html
@@ -75,7 +75,7 @@
 <p class="padding">pg_bigmはgitでソースコードを管理しています。レポジトリは<a href="http://osdn.jp/projects/pgbigm/scm/">ここ</a>です。</p>
 
 <hr>
-<div align="right">Copyright (c) 2017-2022, pg_bigm Development Group</div>
+<div align="right">Copyright (c) 2017-2023, pg_bigm Development Group</div>
 <div align="right">Copyright (c) 2012-2016, NTT DATA Corporation</div>
 
 </body>

--- a/html/index.html
+++ b/html/index.html
@@ -66,6 +66,7 @@
 <p class="padding">pg_bigmはgitでソースコードを管理しています。レポジトリは<a href="http://osdn.jp/projects/pgbigm/scm/">ここ</a>です。</p>
 
 <hr>
+<div align="right">Copyright (c) 2017-2019, pg_bigm Development Group</div>
 <div align="right">Copyright (c) 2012-2016, NTT DATA Corporation</div>
 
 </body>

--- a/html/index.html
+++ b/html/index.html
@@ -23,6 +23,7 @@
 
 <h2 id="news">ニュース</h2>
 <ul>
+<li>2020-04-01: PostgreSQL9.4～12用のpg_bigm-1.2-20200228のRPMファイルをリリースしました。RPMファイルは<a href="https://osdn.net/projects/pgbigm/releases/72448">こちら</a>からダウンロードできます。</li>
 <li>2020-02-28: バージョン1.2の最新マイナーバージョン <a href="https://osdn.net/dl/pgbigm/pg_bigm-1.2-20200228.tar.gz">pg_bigm-1.2-20200228</a>をリリースしました。(<a href="release-1-2.html#release_note_2020-02-28">リリースノート</a>)</li>
 <li>2020-02-28: バージョン1.1の最新マイナーバージョン <a href="https://osdn.net/dl/pgbigm/pg_bigm-1.1-20200228.tar.gz">pg_bigm-1.1-20200228</a>をリリースしました。(<a href="release-1-1.html#release_note_2020-02-28">リリースノート</a>)</li>
 <li>2019-10-03: PostgreSQL 12対応のpg_bigm 1.2最新マイナーバージョン <a href="https://osdn.net/dl/pgbigm/pg_bigm-1.2-20191003.tar.gz">pg_bigm-1.2-20191003</a> をリリースしました。 (<a href="release-1-2.html#release_note_2019-10-03">リリースノート</a>)</li>

--- a/html/index.html
+++ b/html/index.html
@@ -23,6 +23,7 @@
 
 <h2 id="news">ニュース</h2>
 <ul>
+<li>2021-10-07: PostgreSQL14用のpg_bigm-1.2-20200228のRPMファイルをリリースしました。RPMファイルは<a href="https://osdn.net/projects/pgbigm/releases/72448">こちら</a>からダウンロードできます。</li>
 <li>2021-09-30: pg_bigmバージョン 1.2 が PostgreSQL 14 に対応していることを確認しました。</li>
 <li>2020-11-17: PostgreSQL13用のpg_bigm-1.2-20200228のRPMファイルをリリースしました。RPMファイルは<a href="https://osdn.net/projects/pgbigm/releases/72448">こちら</a>からダウンロードできます。</li>
 <li>2020-11-05: pg_bigmバージョン 1.2 が PostgreSQL 13 に対応していることを確認しました。</li>

--- a/html/index.html
+++ b/html/index.html
@@ -23,8 +23,8 @@
 
 <h2 id="news">ニュース</h2>
 <ul>
-<li>2020-02-XX: バージョン1.2の最新マイナーバージョン <a href="https://osdn.net/dl/pgbigm/pg_bigm-1.2-202002XX.tar.gz">pg_bigm-1.2-202002XX</a>をリリースしました。(<a href="release-1-2.html#release_note_2020-02-XX">リリースノート</a>)</li>
-<li>2020-02-XX: バージョン1.1の最新マイナーバージョン <a href="https://osdn.net/dl/pgbigm/pg_bigm-1.1-202002XX.tar.gz">pg_bigm-1.1-202002XX</a>をリリースしました。(<a href="release-1-1.html#release_note_2020-02-XX">リリースノート</a>)</li>
+<li>2020-02-28: バージョン1.2の最新マイナーバージョン <a href="https://osdn.net/dl/pgbigm/pg_bigm-1.2-20200228.tar.gz">pg_bigm-1.2-20200228</a>をリリースしました。(<a href="release-1-2.html#release_note_2020-02-28">リリースノート</a>)</li>
+<li>2020-02-28: バージョン1.1の最新マイナーバージョン <a href="https://osdn.net/dl/pgbigm/pg_bigm-1.1-20200228.tar.gz">pg_bigm-1.1-20200228</a>をリリースしました。(<a href="release-1-1.html#release_note_2020-02-28">リリースノート</a>)</li>
 <li>2019-10-03: PostgreSQL 12対応のpg_bigm 1.2最新マイナーバージョン <a href="https://osdn.net/dl/pgbigm/pg_bigm-1.2-20191003.tar.gz">pg_bigm-1.2-20191003</a> をリリースしました。 (<a href="release-1-2.html#release_note_2019-10-03">リリースノート</a>)</li>
 <li>2018-11-07: pg_bigmバージョン 1.2 と 1.1 が PostgreSQL 11 に対応していることを確認しました。</li>
 <li>2017-10-06: pg_bigmバージョン 1.2 と 1.1 が PostgreSQL 10 に対応していることを確認しました。</li>

--- a/html/index.html
+++ b/html/index.html
@@ -23,6 +23,7 @@
 
 <h2 id="news">ニュース</h2>
 <ul>
+  <li>2019-10-XX: PostgreSQL 12対応のpg_bigm 1.2最新マイナーバージョン <a href="https://osdn.net/dl/pgbigm/pg_bigm-1.2-201910XX.tar.gz">pg_bigm-1.2-201910XX</a> をリリースしました。 (<a href="release-1-2.html#release_note_2019-10-XX">リリースノート</a>)</li>
 <li>2018-11-07: pg_bigmバージョン 1.2 と 1.1 が PostgreSQL 11 に対応していることを確認しました。</li>
 <li>2017-10-06: pg_bigmバージョン 1.2 と 1.1 が PostgreSQL 10 に対応していることを確認しました。</li>
 <li>2016-10-21: PostgreSQL9.1～9.6用のpg_bigm-1.2-20161011のRPMファイルをリリースしました。RPMファイルは<a href="http://osdn.jp/projects/pgbigm/releases/66565">こちら</a>からダウンロードできます。</li>

--- a/html/index.html
+++ b/html/index.html
@@ -23,6 +23,7 @@
 
 <h2 id="news">ニュース</h2>
 <ul>
+<li>2016-10-11: パラレルクエリ対応のpg_bigm最新メジャーバージョン1.2 <a href="https://osdn.net/projects/pgbigm/downloads/66565/pg_bigm-1.2-20161011.tar.gz/">pg_bigm-1.2-20161011</a> をリリースしました。 (<a href="release-1-2.html#release_note_2016-10-11">リリースノート</a>)</li>
 <li>2016-10-11: バージョン1.1の最新マイナーバージョン <a href="https://osdn.net/projects/pgbigm/downloads/66559/pg_bigm-1.1-20161011.tar.gz/">pg_bigm-1.1-20161011</a>をリリースしました。(<a href="release-1-1.html#release_note_2016-10-11">リリースノート</a>)</li>
 <li>2016-01-15: PostgreSQL9.1～9.5用のpg_bigm 1.1-20150910のRPMファイルをリリースしました。RPMファイルは<a href="http://osdn.jp/projects/pgbigm/releases/63792">こちら</a>からダウンロードできます。</li>
 <li>2016-01-13: pg_bigmバージョン1.1がPostgreSQL9.5に対応していることを確認しました。</li>

--- a/html/index.html
+++ b/html/index.html
@@ -23,6 +23,7 @@
 
 <h2 id="news">ニュース</h2>
 <ul>
+<li>2016-10-21: PostgreSQL9.1～9.6用のpg_bigm-1.2-20161011のRPMファイルをリリースしました。RPMファイルは<a href="http://osdn.jp/projects/pgbigm/releases/66565">こちら</a>からダウンロードできます。</li>
 <li>2016-10-11: パラレルクエリ対応のpg_bigm最新メジャーバージョン1.2 <a href="https://osdn.net/projects/pgbigm/downloads/66565/pg_bigm-1.2-20161011.tar.gz/">pg_bigm-1.2-20161011</a> をリリースしました。 (<a href="release-1-2.html#release_note_2016-10-11">リリースノート</a>)</li>
 <li>2016-10-11: バージョン1.1の最新マイナーバージョン <a href="https://osdn.net/projects/pgbigm/downloads/66559/pg_bigm-1.1-20161011.tar.gz/">pg_bigm-1.1-20161011</a>をリリースしました。(<a href="release-1-1.html#release_note_2016-10-11">リリースノート</a>)</li>
 <li>2016-01-15: PostgreSQL9.1～9.5用のpg_bigm 1.1-20150910のRPMファイルをリリースしました。RPMファイルは<a href="http://osdn.jp/projects/pgbigm/releases/63792">こちら</a>からダウンロードできます。</li>

--- a/html/index.html
+++ b/html/index.html
@@ -23,6 +23,7 @@
 
 <h2 id="news">ニュース</h2>
 <ul>
+<li>2020-11-17: PostgreSQL13用のpg_bigm-1.2-20200228のRPMファイルをリリースしました。RPMファイルは<a href="https://osdn.net/projects/pgbigm/releases/72448">こちら</a>からダウンロードできます。</li>
 <li>2020-11-05: pg_bigmバージョン 1.2 が PostgreSQL 13 に対応していることを確認しました。</li>
 <li>2020-04-01: PostgreSQL9.4～12用のpg_bigm-1.2-20200228のRPMファイルをリリースしました。RPMファイルは<a href="https://osdn.net/projects/pgbigm/releases/72448">こちら</a>からダウンロードできます。</li>
 <li>2020-02-28: バージョン1.2の最新マイナーバージョン <a href="https://osdn.net/dl/pgbigm/pg_bigm-1.2-20200228.tar.gz">pg_bigm-1.2-20200228</a>をリリースしました。(<a href="release-1-2.html#release_note_2020-02-28">リリースノート</a>)</li>

--- a/html/index.html
+++ b/html/index.html
@@ -23,6 +23,7 @@
 
 <h2 id="news">ニュース</h2>
 <ul>
+<li>2017-10-06: pg_bigmバージョン 1.2 と 1.1 が PostgreSQL 10 に対応していることを確認しました。</li>
 <li>2016-10-21: PostgreSQL9.1～9.6用のpg_bigm-1.2-20161011のRPMファイルをリリースしました。RPMファイルは<a href="http://osdn.jp/projects/pgbigm/releases/66565">こちら</a>からダウンロードできます。</li>
 <li>2016-10-11: パラレルクエリ対応のpg_bigm最新メジャーバージョン1.2 <a href="https://osdn.net/projects/pgbigm/downloads/66565/pg_bigm-1.2-20161011.tar.gz/">pg_bigm-1.2-20161011</a> をリリースしました。 (<a href="release-1-2.html#release_note_2016-10-11">リリースノート</a>)</li>
 <li>2016-10-11: バージョン1.1の最新マイナーバージョン <a href="https://osdn.net/projects/pgbigm/downloads/66559/pg_bigm-1.1-20161011.tar.gz/">pg_bigm-1.1-20161011</a>をリリースしました。(<a href="release-1-1.html#release_note_2016-10-11">リリースノート</a>)</li>

--- a/html/index.html
+++ b/html/index.html
@@ -23,6 +23,7 @@
 
 <h2 id="news">ニュース</h2>
 <ul>
+<li>2022-10-24: PostgreSQL15用のpg_bigm-1.2-20200228のRPMファイルをリリースしました。RPMファイルは<a href="https://osdn.net/projects/pgbigm/releases/72448">こちら</a>からダウンロードできます。</li>
 <li>2022-10-13: pg_bigmバージョン 1.2 が PostgreSQL 15 に対応していることを確認しました。</li>
 <li>2021-10-07: PostgreSQL14用のpg_bigm-1.2-20200228のRPMファイルをリリースしました。RPMファイルは<a href="https://osdn.net/projects/pgbigm/releases/72448">こちら</a>からダウンロードできます。</li>
 <li>2021-09-30: pg_bigmバージョン 1.2 が PostgreSQL 14 に対応していることを確認しました。</li>

--- a/html/index.html
+++ b/html/index.html
@@ -23,7 +23,7 @@
 
 <h2 id="news">ニュース</h2>
 <ul>
-  <li>2019-10-XX: PostgreSQL 12対応のpg_bigm 1.2最新マイナーバージョン <a href="https://osdn.net/dl/pgbigm/pg_bigm-1.2-201910XX.tar.gz">pg_bigm-1.2-201910XX</a> をリリースしました。 (<a href="release-1-2.html#release_note_2019-10-XX">リリースノート</a>)</li>
+  <li>2019-10-03: PostgreSQL 12対応のpg_bigm 1.2最新マイナーバージョン <a href="https://osdn.net/dl/pgbigm/pg_bigm-1.2-20191003.tar.gz">pg_bigm-1.2-20191003</a> をリリースしました。 (<a href="release-1-2.html#release_note_2019-10-03">リリースノート</a>)</li>
 <li>2018-11-07: pg_bigmバージョン 1.2 と 1.1 が PostgreSQL 11 に対応していることを確認しました。</li>
 <li>2017-10-06: pg_bigmバージョン 1.2 と 1.1 が PostgreSQL 10 に対応していることを確認しました。</li>
 <li>2016-10-21: PostgreSQL9.1～9.6用のpg_bigm-1.2-20161011のRPMファイルをリリースしました。RPMファイルは<a href="http://osdn.jp/projects/pgbigm/releases/66565">こちら</a>からダウンロードできます。</li>

--- a/html/index.html
+++ b/html/index.html
@@ -23,6 +23,7 @@
 
 <h2 id="news">ニュース</h2>
 <ul>
+<li>2020-11-05: pg_bigmバージョン 1.2 が PostgreSQL 13 に対応していることを確認しました。</li>
 <li>2020-04-01: PostgreSQL9.4～12用のpg_bigm-1.2-20200228のRPMファイルをリリースしました。RPMファイルは<a href="https://osdn.net/projects/pgbigm/releases/72448">こちら</a>からダウンロードできます。</li>
 <li>2020-02-28: バージョン1.2の最新マイナーバージョン <a href="https://osdn.net/dl/pgbigm/pg_bigm-1.2-20200228.tar.gz">pg_bigm-1.2-20200228</a>をリリースしました。(<a href="release-1-2.html#release_note_2020-02-28">リリースノート</a>)</li>
 <li>2020-02-28: バージョン1.1の最新マイナーバージョン <a href="https://osdn.net/dl/pgbigm/pg_bigm-1.1-20200228.tar.gz">pg_bigm-1.1-20200228</a>をリリースしました。(<a href="release-1-1.html#release_note_2020-02-28">リリースノート</a>)</li>

--- a/html/index.html
+++ b/html/index.html
@@ -23,6 +23,7 @@
 
 <h2 id="news">ニュース</h2>
 <ul>
+<li>2018-11-07: pg_bigmバージョン 1.2 と 1.1 が PostgreSQL 11 に対応していることを確認しました。</li>
 <li>2017-10-06: pg_bigmバージョン 1.2 と 1.1 が PostgreSQL 10 に対応していることを確認しました。</li>
 <li>2016-10-21: PostgreSQL9.1～9.6用のpg_bigm-1.2-20161011のRPMファイルをリリースしました。RPMファイルは<a href="http://osdn.jp/projects/pgbigm/releases/66565">こちら</a>からダウンロードできます。</li>
 <li>2016-10-11: パラレルクエリ対応のpg_bigm最新メジャーバージョン1.2 <a href="https://osdn.net/projects/pgbigm/downloads/66565/pg_bigm-1.2-20161011.tar.gz/">pg_bigm-1.2-20161011</a> をリリースしました。 (<a href="release-1-2.html#release_note_2016-10-11">リリースノート</a>)</li>

--- a/html/index.html
+++ b/html/index.html
@@ -23,6 +23,7 @@
 
 <h2 id="news">ニュース</h2>
 <ul>
+<li>2021-09-30: pg_bigmバージョン 1.2 が PostgreSQL 14 に対応していることを確認しました。</li>
 <li>2020-11-17: PostgreSQL13用のpg_bigm-1.2-20200228のRPMファイルをリリースしました。RPMファイルは<a href="https://osdn.net/projects/pgbigm/releases/72448">こちら</a>からダウンロードできます。</li>
 <li>2020-11-05: pg_bigmバージョン 1.2 が PostgreSQL 13 に対応していることを確認しました。</li>
 <li>2020-04-01: PostgreSQL9.4～12用のpg_bigm-1.2-20200228のRPMファイルをリリースしました。RPMファイルは<a href="https://osdn.net/projects/pgbigm/releases/72448">こちら</a>からダウンロードできます。</li>

--- a/html/index_en.html
+++ b/html/index_en.html
@@ -23,6 +23,7 @@
 
 <h2 id="news">News</h2>
 <ul>
+<li>2022-10-13: pg_bigm 1.2 was confirmed to work with PostgreSQL 15.</li>
 <li>2021-10-07: The RPM files of pg_bigm 1.2-20200228 for PostgreSQL 14 were released. They can be downloaded from <a href="https://en.osdn.net/projects/pgbigm/releases/72448">here</a>.</li>
 <li>2021-09-30: pg_bigm 1.2 was confirmed to work with PostgreSQL 14.</li>
 <li>2020-11-17: The RPM files of pg_bigm 1.2-20200228 for PostgreSQL 13 were released. They can be downloaded from <a href="https://en.osdn.net/projects/pgbigm/releases/72448">here</a>.</li>

--- a/html/index_en.html
+++ b/html/index_en.html
@@ -23,6 +23,7 @@
 
 <h2 id="news">News</h2>
 <ul>
+<li>2020-11-17: The RPM files of pg_bigm 1.2-20200228 for PostgreSQL 13 were released. They can be downloaded from <a href="https://en.osdn.net/projects/pgbigm/releases/72448">here</a>.</li>
 <li>2020-11-05: pg_bigm 1.2 was confirmed to work with PostgreSQL 13.</li>
 <li>2020-04-01: The RPM files of pg_bigm 1.2-20200228 for PostgreSQL 9.4 to 12 were released. They can be downloaded from <a href="https://en.osdn.net/projects/pgbigm/releases/72448">here</a>.</li>
 <li>2020-02-28: The latest minor version of pg_bigm 1.2, <a href="https://en.osdn.net/dl/pgbigm/pg_bigm-1.2-20200228.tar.gz">pg_bigm-1.2-20200228</a> was released.(<a href="release-1-2_en.html#release_note_2020-02-28">Release Note</a>)</li>

--- a/html/index_en.html
+++ b/html/index_en.html
@@ -23,6 +23,7 @@
 
 <h2 id="news">News</h2>
 <ul>
+<li>2021-10-07: The RPM files of pg_bigm 1.2-20200228 for PostgreSQL 14 were released. They can be downloaded from <a href="https://en.osdn.net/projects/pgbigm/releases/72448">here</a>.</li>
 <li>2021-09-30: pg_bigm 1.2 was confirmed to work with PostgreSQL 14.</li>
 <li>2020-11-17: The RPM files of pg_bigm 1.2-20200228 for PostgreSQL 13 were released. They can be downloaded from <a href="https://en.osdn.net/projects/pgbigm/releases/72448">here</a>.</li>
 <li>2020-11-05: pg_bigm 1.2 was confirmed to work with PostgreSQL 13.</li>

--- a/html/index_en.html
+++ b/html/index_en.html
@@ -23,7 +23,7 @@
 
 <h2 id="news">News</h2>
 <ul>
-<li>2019-10-XX: The latest minor version of pg_bigm 1.2, <a href="https://en.osdn.net/dl/pgbigm/pg_bigm-1.2-201910XX.tar.gz">pg_bigm-1.2-201910XX</a> was released. (<a href="release-1-2_en.html#release_note_2019-10-XX">Release Note</a>)</li>
+<li>2019-10-03: The latest minor version of pg_bigm 1.2, <a href="https://en.osdn.net/dl/pgbigm/pg_bigm-1.2-20191003.tar.gz">pg_bigm-1.2-20191003</a> was released. (<a href="release-1-2_en.html#release_note_2019-10-03">Release Note</a>)</li>
 <li>2018-11-07: pg_bigm 1.2 and 1.1 were confirmed to work with PostgreSQL 11.</li>
 <li>2017-10-06: pg_bigm 1.2 and 1.1 were confirmed to work with PostgreSQL 10.</li>
 <li>2016-10-21: The RPM files of pg_bigm 1.2-20161011 for PostgreSQL 9.1 to 9.6 were released. They can be downloaded from <a href="http://en.osdn.jp/projects/pgbigm/releases/66565">here</a>.</li>

--- a/html/index_en.html
+++ b/html/index_en.html
@@ -23,6 +23,7 @@
 
 <h2 id="news">News</h2>
 <ul>
+<li>2021-09-30: pg_bigm 1.2 was confirmed to work with PostgreSQL 14.</li>
 <li>2020-11-17: The RPM files of pg_bigm 1.2-20200228 for PostgreSQL 13 were released. They can be downloaded from <a href="https://en.osdn.net/projects/pgbigm/releases/72448">here</a>.</li>
 <li>2020-11-05: pg_bigm 1.2 was confirmed to work with PostgreSQL 13.</li>
 <li>2020-04-01: The RPM files of pg_bigm 1.2-20200228 for PostgreSQL 9.4 to 12 were released. They can be downloaded from <a href="https://en.osdn.net/projects/pgbigm/releases/72448">here</a>.</li>

--- a/html/index_en.html
+++ b/html/index_en.html
@@ -23,6 +23,7 @@
 
 <h2 id="news">News</h2>
 <ul>
+<li>2020-02-XX: The latest minor version of pg_bigm 1.2, <a href="https://en.osdn.net/dl/pgbigm/pg_bigm-1.2-202002XX.tar.gz">pg_bigm-1.2-202002XX</a> was released.(<a href="release-1-2_en.html#release_note_2020-02-XX">Release Note</a>)</li>
 <li>2020-02-XX: The latest minor version of pg_bigm 1.1, <a href="https://en.osdn.net/dl/pgbigm/pg_bigm-1.1-202002XX.tar.gz">pg_bigm-1.1-202002XX</a> was released.(<a href="release-1-1_en.html#release_note_2020-02-XX">Release Note</a>)</li>
 <li>2019-10-03: The latest minor version of pg_bigm 1.2, <a href="https://en.osdn.net/dl/pgbigm/pg_bigm-1.2-20191003.tar.gz">pg_bigm-1.2-20191003</a> was released. (<a href="release-1-2_en.html#release_note_2019-10-03">Release Note</a>)</li>
 <li>2018-11-07: pg_bigm 1.2 and 1.1 were confirmed to work with PostgreSQL 11.</li>

--- a/html/index_en.html
+++ b/html/index_en.html
@@ -23,6 +23,7 @@
 
 <h2 id="news">News</h2>
 <ul>
+<li>2016-10-11: pg_bigm 1.2, the latest major version <a href="http://en.osdn.jp/projects/pgbigm/downloads/66565/pg_bigm-1.2-20161011.tar.gz/">pg_bigm-1.2-20161011</a> was released. (<a href="release-1-2_en.html#release_note_2016-10-11">Release Note</a>)</li>
 <li>2016-10-11: The latest minor version of pg_bigm 1.1, <a href="http://en.osdn.jp/projects/pgbigm/downloads/66559/pg_bigm-1.1-20161011.tar.gz/">pg_bigm-1.1-20161011</a> was released.(<a href="release-1-1_en.html#release_note_2016-10-11">Release Note</a>)</li>
 <li>2016-01-15: The RPM files of pg_bigm 1.1-20150910 for PostgreSQL 9.1 to 9.5 were released. They can be downloaded from <a href="http://en.osdn.jp/projects/pgbigm/releases/63792">here</a>.</li>
 <li>2016-01-13: pg_bigm 1.1 was confirmed to work with <a href="http://www.postgresql.org/about/press/presskit95/">PostgreSQL9.5</a>.</li>

--- a/html/index_en.html
+++ b/html/index_en.html
@@ -23,6 +23,7 @@
 
 <h2 id="news">News</h2>
 <ul>
+<li>2017-10-06: pg_bigm 1.2 and 1.1 were confirmed to work with PostgreSQL 10.</li>
 <li>2016-10-21: The RPM files of pg_bigm 1.2-20161011 for PostgreSQL 9.1 to 9.6 were released. They can be downloaded from <a href="http://en.osdn.jp/projects/pgbigm/releases/66565">here</a>.</li>
 <li>2016-10-11: pg_bigm 1.2, the latest major version <a href="http://en.osdn.jp/projects/pgbigm/downloads/66565/pg_bigm-1.2-20161011.tar.gz/">pg_bigm-1.2-20161011</a> was released. (<a href="release-1-2_en.html#release_note_2016-10-11">Release Note</a>)</li>
 <li>2016-10-11: The latest minor version of pg_bigm 1.1, <a href="http://en.osdn.jp/projects/pgbigm/downloads/66559/pg_bigm-1.1-20161011.tar.gz/">pg_bigm-1.1-20161011</a> was released.(<a href="release-1-1_en.html#release_note_2016-10-11">Release Note</a>)</li>

--- a/html/index_en.html
+++ b/html/index_en.html
@@ -66,7 +66,7 @@
 <p class="padding">The pg_bigm source code is now maintained in a git repository available <a href="http://en.osdn.jp/projects/pgbigm/scm/">here</a>.</p>
 
 <hr>
-<div align="right">Copyright (c) 2017-2019, pg_bigm Development Group</div>
+<div align="right">Copyright (c) 2017-2020, pg_bigm Development Group</div>
 <div align="right">Copyright (c) 2012-2016, NTT DATA Corporation</div>
 
 </body>

--- a/html/index_en.html
+++ b/html/index_en.html
@@ -23,6 +23,7 @@
 
 <h2 id="news">News</h2>
 <ul>
+<li>2020-02-XX: The latest minor version of pg_bigm 1.1, <a href="https://en.osdn.net/dl/pgbigm/pg_bigm-1.1-202002XX.tar.gz">pg_bigm-1.1-202002XX</a> was released.(<a href="release-1-1_en.html#release_note_2020-02-XX">Release Note</a>)</li>
 <li>2019-10-03: The latest minor version of pg_bigm 1.2, <a href="https://en.osdn.net/dl/pgbigm/pg_bigm-1.2-20191003.tar.gz">pg_bigm-1.2-20191003</a> was released. (<a href="release-1-2_en.html#release_note_2019-10-03">Release Note</a>)</li>
 <li>2018-11-07: pg_bigm 1.2 and 1.1 were confirmed to work with PostgreSQL 11.</li>
 <li>2017-10-06: pg_bigm 1.2 and 1.1 were confirmed to work with PostgreSQL 10.</li>

--- a/html/index_en.html
+++ b/html/index_en.html
@@ -23,6 +23,7 @@
 
 <h2 id="news">News</h2>
 <ul>
+<li>2020-11-05: pg_bigm 1.2 was confirmed to work with PostgreSQL 13.</li>
 <li>2020-04-01: The RPM files of pg_bigm 1.2-20200228 for PostgreSQL 9.4 to 12 were released. They can be downloaded from <a href="https://en.osdn.net/projects/pgbigm/releases/72448">here</a>.</li>
 <li>2020-02-28: The latest minor version of pg_bigm 1.2, <a href="https://en.osdn.net/dl/pgbigm/pg_bigm-1.2-20200228.tar.gz">pg_bigm-1.2-20200228</a> was released.(<a href="release-1-2_en.html#release_note_2020-02-28">Release Note</a>)</li>
 <li>2020-02-28: The latest minor version of pg_bigm 1.1, <a href="https://en.osdn.net/dl/pgbigm/pg_bigm-1.1-20200228.tar.gz">pg_bigm-1.1-20200228</a> was released.(<a href="release-1-1_en.html#release_note_2020-02-28">Release Note</a>)</li>

--- a/html/index_en.html
+++ b/html/index_en.html
@@ -23,6 +23,7 @@
 
 <h2 id="news">News</h2>
 <ul>
+<li>2020-04-01: The RPM files of pg_bigm 1.2-20200228 for PostgreSQL 9.4 to 12 were released. They can be downloaded from <a href="https://en.osdn.net/projects/pgbigm/releases/72448">here</a>.</li>
 <li>2020-02-28: The latest minor version of pg_bigm 1.2, <a href="https://en.osdn.net/dl/pgbigm/pg_bigm-1.2-20200228.tar.gz">pg_bigm-1.2-20200228</a> was released.(<a href="release-1-2_en.html#release_note_2020-02-28">Release Note</a>)</li>
 <li>2020-02-28: The latest minor version of pg_bigm 1.1, <a href="https://en.osdn.net/dl/pgbigm/pg_bigm-1.1-20200228.tar.gz">pg_bigm-1.1-20200228</a> was released.(<a href="release-1-1_en.html#release_note_2020-02-28">Release Note</a>)</li>
 <li>2019-10-03: The latest minor version of pg_bigm 1.2, <a href="https://en.osdn.net/dl/pgbigm/pg_bigm-1.2-20191003.tar.gz">pg_bigm-1.2-20191003</a> was released. (<a href="release-1-2_en.html#release_note_2019-10-03">Release Note</a>)</li>

--- a/html/index_en.html
+++ b/html/index_en.html
@@ -23,6 +23,7 @@
 
 <h2 id="news">News</h2>
 <ul>
+<li>2018-11-07: pg_bigm 1.2 and 1.1 were confirmed to work with PostgreSQL 11.</li>
 <li>2017-10-06: pg_bigm 1.2 and 1.1 were confirmed to work with PostgreSQL 10.</li>
 <li>2016-10-21: The RPM files of pg_bigm 1.2-20161011 for PostgreSQL 9.1 to 9.6 were released. They can be downloaded from <a href="http://en.osdn.jp/projects/pgbigm/releases/66565">here</a>.</li>
 <li>2016-10-11: pg_bigm 1.2, the latest major version <a href="http://en.osdn.jp/projects/pgbigm/downloads/66565/pg_bigm-1.2-20161011.tar.gz/">pg_bigm-1.2-20161011</a> was released. (<a href="release-1-2_en.html#release_note_2016-10-11">Release Note</a>)</li>

--- a/html/index_en.html
+++ b/html/index_en.html
@@ -23,6 +23,7 @@
 
 <h2 id="news">News</h2>
 <ul>
+<li>2023-02-17: The RPM files of pg_bigm 1.2-20200228 on PostgreSQL 11 to 15 for RHEL 9 family were released. They can be downloaded from <a href="https://en.osdn.net/projects/pgbigm/releases/72448">here</a>.</li>
 <li>2022-10-24: The RPM files of pg_bigm 1.2-20200228 for PostgreSQL 15 were released. They can be downloaded from <a href="https://en.osdn.net/projects/pgbigm/releases/72448">here</a>.</li>
 <li>2022-10-13: pg_bigm 1.2 was confirmed to work with PostgreSQL 15.</li>
 <li>2021-10-07: The RPM files of pg_bigm 1.2-20200228 for PostgreSQL 14 were released. They can be downloaded from <a href="https://en.osdn.net/projects/pgbigm/releases/72448">here</a>.</li>

--- a/html/index_en.html
+++ b/html/index_en.html
@@ -66,6 +66,7 @@
 <p class="padding">The pg_bigm source code is now maintained in a git repository available <a href="http://en.osdn.jp/projects/pgbigm/scm/">here</a>.</p>
 
 <hr>
+<div align="right">Copyright (c) 2017-2019, pg_bigm Development Group</div>
 <div align="right">Copyright (c) 2012-2016, NTT DATA Corporation</div>
 
 </body>

--- a/html/index_en.html
+++ b/html/index_en.html
@@ -23,6 +23,7 @@
 
 <h2 id="news">News</h2>
 <ul>
+<li>2022-10-24: The RPM files of pg_bigm 1.2-20200228 for PostgreSQL 15 were released. They can be downloaded from <a href="https://en.osdn.net/projects/pgbigm/releases/72448">here</a>.</li>
 <li>2022-10-13: pg_bigm 1.2 was confirmed to work with PostgreSQL 15.</li>
 <li>2021-10-07: The RPM files of pg_bigm 1.2-20200228 for PostgreSQL 14 were released. They can be downloaded from <a href="https://en.osdn.net/projects/pgbigm/releases/72448">here</a>.</li>
 <li>2021-09-30: pg_bigm 1.2 was confirmed to work with PostgreSQL 14.</li>

--- a/html/index_en.html
+++ b/html/index_en.html
@@ -23,6 +23,7 @@
 
 <h2 id="news">News</h2>
 <ul>
+<li>2016-10-21: The RPM files of pg_bigm 1.2-20161011 for PostgreSQL 9.1 to 9.6 were released. They can be downloaded from <a href="http://en.osdn.jp/projects/pgbigm/releases/66565">here</a>.</li>
 <li>2016-10-11: pg_bigm 1.2, the latest major version <a href="http://en.osdn.jp/projects/pgbigm/downloads/66565/pg_bigm-1.2-20161011.tar.gz/">pg_bigm-1.2-20161011</a> was released. (<a href="release-1-2_en.html#release_note_2016-10-11">Release Note</a>)</li>
 <li>2016-10-11: The latest minor version of pg_bigm 1.1, <a href="http://en.osdn.jp/projects/pgbigm/downloads/66559/pg_bigm-1.1-20161011.tar.gz/">pg_bigm-1.1-20161011</a> was released.(<a href="release-1-1_en.html#release_note_2016-10-11">Release Note</a>)</li>
 <li>2016-01-15: The RPM files of pg_bigm 1.1-20150910 for PostgreSQL 9.1 to 9.5 were released. They can be downloaded from <a href="http://en.osdn.jp/projects/pgbigm/releases/63792">here</a>.</li>

--- a/html/index_en.html
+++ b/html/index_en.html
@@ -23,6 +23,7 @@
 
 <h2 id="news">News</h2>
 <ul>
+<li>2019-10-XX: The latest minor version of pg_bigm 1.2, <a href="https://en.osdn.net/dl/pgbigm/pg_bigm-1.2-201910XX.tar.gz">pg_bigm-1.2-201910XX</a> was released. (<a href="release-1-2_en.html#release_note_2019-10-XX">Release Note</a>)</li>
 <li>2018-11-07: pg_bigm 1.2 and 1.1 were confirmed to work with PostgreSQL 11.</li>
 <li>2017-10-06: pg_bigm 1.2 and 1.1 were confirmed to work with PostgreSQL 10.</li>
 <li>2016-10-21: The RPM files of pg_bigm 1.2-20161011 for PostgreSQL 9.1 to 9.6 were released. They can be downloaded from <a href="http://en.osdn.jp/projects/pgbigm/releases/66565">here</a>.</li>

--- a/html/index_en.html
+++ b/html/index_en.html
@@ -23,8 +23,8 @@
 
 <h2 id="news">News</h2>
 <ul>
-<li>2020-02-XX: The latest minor version of pg_bigm 1.2, <a href="https://en.osdn.net/dl/pgbigm/pg_bigm-1.2-202002XX.tar.gz">pg_bigm-1.2-202002XX</a> was released.(<a href="release-1-2_en.html#release_note_2020-02-XX">Release Note</a>)</li>
-<li>2020-02-XX: The latest minor version of pg_bigm 1.1, <a href="https://en.osdn.net/dl/pgbigm/pg_bigm-1.1-202002XX.tar.gz">pg_bigm-1.1-202002XX</a> was released.(<a href="release-1-1_en.html#release_note_2020-02-XX">Release Note</a>)</li>
+<li>2020-02-28: The latest minor version of pg_bigm 1.2, <a href="https://en.osdn.net/dl/pgbigm/pg_bigm-1.2-20200228.tar.gz">pg_bigm-1.2-20200228</a> was released.(<a href="release-1-2_en.html#release_note_2020-02-28">Release Note</a>)</li>
+<li>2020-02-28: The latest minor version of pg_bigm 1.1, <a href="https://en.osdn.net/dl/pgbigm/pg_bigm-1.1-20200228.tar.gz">pg_bigm-1.1-20200228</a> was released.(<a href="release-1-1_en.html#release_note_2020-02-28">Release Note</a>)</li>
 <li>2019-10-03: The latest minor version of pg_bigm 1.2, <a href="https://en.osdn.net/dl/pgbigm/pg_bigm-1.2-20191003.tar.gz">pg_bigm-1.2-20191003</a> was released. (<a href="release-1-2_en.html#release_note_2019-10-03">Release Note</a>)</li>
 <li>2018-11-07: pg_bigm 1.2 and 1.1 were confirmed to work with PostgreSQL 11.</li>
 <li>2017-10-06: pg_bigm 1.2 and 1.1 were confirmed to work with PostgreSQL 10.</li>

--- a/html/index_en.html
+++ b/html/index_en.html
@@ -73,7 +73,7 @@
 <p class="padding">The pg_bigm source code is now maintained in a git repository available <a href="http://en.osdn.jp/projects/pgbigm/scm/">here</a>.</p>
 
 <hr>
-<div align="right">Copyright (c) 2017-2021, pg_bigm Development Group</div>
+<div align="right">Copyright (c) 2017-2022, pg_bigm Development Group</div>
 <div align="right">Copyright (c) 2012-2016, NTT DATA Corporation</div>
 
 </body>

--- a/html/index_en.html
+++ b/html/index_en.html
@@ -71,7 +71,7 @@
 <p class="padding">The pg_bigm source code is now maintained in a git repository available <a href="http://en.osdn.jp/projects/pgbigm/scm/">here</a>.</p>
 
 <hr>
-<div align="right">Copyright (c) 2017-2020, pg_bigm Development Group</div>
+<div align="right">Copyright (c) 2017-2021, pg_bigm Development Group</div>
 <div align="right">Copyright (c) 2012-2016, NTT DATA Corporation</div>
 
 </body>

--- a/html/index_en.html
+++ b/html/index_en.html
@@ -75,7 +75,7 @@
 <p class="padding">The pg_bigm source code is now maintained in a git repository available <a href="http://en.osdn.jp/projects/pgbigm/scm/">here</a>.</p>
 
 <hr>
-<div align="right">Copyright (c) 2017-2022, pg_bigm Development Group</div>
+<div align="right">Copyright (c) 2017-2023, pg_bigm Development Group</div>
 <div align="right">Copyright (c) 2012-2016, NTT DATA Corporation</div>
 
 </body>

--- a/html/pg_bigm-1-2.html
+++ b/html/pg_bigm-1-2.html
@@ -114,7 +114,7 @@
 </tr>
 <tr>
   <td>DBMS</td>
-  <td nowrap>PostgreSQL 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 10, 11, 12</td>
+  <td nowrap>PostgreSQL 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 10, 11, 12, 13</td>
 </tr>
 </tbody>
 </table>

--- a/html/pg_bigm-1-2.html
+++ b/html/pg_bigm-1-2.html
@@ -517,7 +517,7 @@ ERROR:  out of memory
 </ul>
 
 <hr>
-<div align="right">Copyright (c) 2017-2022, pg_bigm Development Group</div>
+<div align="right">Copyright (c) 2017-2023, pg_bigm Development Group</div>
 <div align="right">Copyright (c) 2012-2016, NTT DATA Corporation</div>
 
 </body>

--- a/html/pg_bigm-1-2.html
+++ b/html/pg_bigm-1-2.html
@@ -114,7 +114,7 @@
 </tr>
 <tr>
   <td>DBMS</td>
-  <td nowrap>PostgreSQL 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 10</td>
+  <td nowrap>PostgreSQL 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 10, 11</td>
 </tr>
 </tbody>
 </table>

--- a/html/pg_bigm-1-2.html
+++ b/html/pg_bigm-1-2.html
@@ -114,7 +114,7 @@
 </tr>
 <tr>
   <td>DBMS</td>
-  <td nowrap>PostgreSQL 9.1, 9.2, 9.3, 9.4, 9.5, 9.6</td>
+  <td nowrap>PostgreSQL 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 10</td>
 </tr>
 </tbody>
 </table>

--- a/html/pg_bigm-1-2.html
+++ b/html/pg_bigm-1-2.html
@@ -114,7 +114,7 @@
 </tr>
 <tr>
   <td>DBMS</td>
-  <td nowrap>PostgreSQL 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 10, 11, 12, 13</td>
+  <td nowrap>PostgreSQL 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 10, 11, 12, 13, 14</td>
 </tr>
 </tbody>
 </table>

--- a/html/pg_bigm-1-2.html
+++ b/html/pg_bigm-1-2.html
@@ -114,7 +114,7 @@
 </tr>
 <tr>
   <td>DBMS</td>
-  <td nowrap>PostgreSQL 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 10, 11</td>
+  <td nowrap>PostgreSQL 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 10, 11, 12</td>
 </tr>
 </tbody>
 </table>

--- a/html/pg_bigm-1-2.html
+++ b/html/pg_bigm-1-2.html
@@ -517,7 +517,7 @@ ERROR:  out of memory
 </ul>
 
 <hr>
-<div align="right">Copyright (c) 2017-2021, pg_bigm Development Group</div>
+<div align="right">Copyright (c) 2017-2022, pg_bigm Development Group</div>
 <div align="right">Copyright (c) 2012-2016, NTT DATA Corporation</div>
 
 </body>

--- a/html/pg_bigm-1-2.html
+++ b/html/pg_bigm-1-2.html
@@ -517,6 +517,7 @@ ERROR:  out of memory
 </ul>
 
 <hr>
+<div align="right">Copyright (c) 2017-2019, pg_bigm Development Group</div>
 <div align="right">Copyright (c) 2012-2016, NTT DATA Corporation</div>
 
 </body>

--- a/html/pg_bigm-1-2.html
+++ b/html/pg_bigm-1-2.html
@@ -517,7 +517,7 @@ ERROR:  out of memory
 </ul>
 
 <hr>
-<div align="right">Copyright (c) 2017-2020, pg_bigm Development Group</div>
+<div align="right">Copyright (c) 2017-2021, pg_bigm Development Group</div>
 <div align="right">Copyright (c) 2012-2016, NTT DATA Corporation</div>
 
 </body>

--- a/html/pg_bigm-1-2.html
+++ b/html/pg_bigm-1-2.html
@@ -114,7 +114,7 @@
 </tr>
 <tr>
   <td>DBMS</td>
-  <td nowrap>PostgreSQL 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 10, 11, 12, 13, 14</td>
+  <td nowrap>PostgreSQL 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 10, 11, 12, 13, 14, 15</td>
 </tr>
 </tbody>
 </table>

--- a/html/pg_bigm-1-2.html
+++ b/html/pg_bigm-1-2.html
@@ -517,7 +517,7 @@ ERROR:  out of memory
 </ul>
 
 <hr>
-<div align="right">Copyright (c) 2017-2019, pg_bigm Development Group</div>
+<div align="right">Copyright (c) 2017-2020, pg_bigm Development Group</div>
 <div align="right">Copyright (c) 2012-2016, NTT DATA Corporation</div>
 
 </body>

--- a/html/pg_bigm_en-1-2.html
+++ b/html/pg_bigm_en-1-2.html
@@ -114,7 +114,7 @@ For example, x.y is 1.1 and YYYYMMDD is 20131122 if the file of the version 1.1 
 </tr>
 <tr>
   <td>DBMS</td>
-  <td nowrap>PostgreSQL 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 10, 11, 12, 13, 14</td>
+  <td nowrap>PostgreSQL 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 10, 11, 12, 13, 14, 15</td>
 </tr>
 </tbody>
 </table>

--- a/html/pg_bigm_en-1-2.html
+++ b/html/pg_bigm_en-1-2.html
@@ -516,7 +516,7 @@ ERROR:  out of memory
 </ul>
 
 <hr>
-<div align="right">Copyright (c) 2017-2022, pg_bigm Development Group</div>
+<div align="right">Copyright (c) 2017-2023, pg_bigm Development Group</div>
 <div align="right">Copyright (c) 2012-2016, NTT DATA Corporation</div>
 
 </body>

--- a/html/pg_bigm_en-1-2.html
+++ b/html/pg_bigm_en-1-2.html
@@ -114,7 +114,7 @@ For example, x.y is 1.1 and YYYYMMDD is 20131122 if the file of the version 1.1 
 </tr>
 <tr>
   <td>DBMS</td>
-  <td nowrap>PostgreSQL 9.1, 9.2, 9.3, 9.4, 9.5, 9.6</td>
+  <td nowrap>PostgreSQL 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 10</td>
 </tr>
 </tbody>
 </table>

--- a/html/pg_bigm_en-1-2.html
+++ b/html/pg_bigm_en-1-2.html
@@ -114,7 +114,7 @@ For example, x.y is 1.1 and YYYYMMDD is 20131122 if the file of the version 1.1 
 </tr>
 <tr>
   <td>DBMS</td>
-  <td nowrap>PostgreSQL 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 10, 11, 12</td>
+  <td nowrap>PostgreSQL 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 10, 11, 12, 13</td>
 </tr>
 </tbody>
 </table>

--- a/html/pg_bigm_en-1-2.html
+++ b/html/pg_bigm_en-1-2.html
@@ -516,7 +516,7 @@ ERROR:  out of memory
 </ul>
 
 <hr>
-<div align="right">Copyright (c) 2017-2019, pg_bigm Development Group</div>
+<div align="right">Copyright (c) 2017-2020, pg_bigm Development Group</div>
 <div align="right">Copyright (c) 2012-2016, NTT DATA Corporation</div>
 
 </body>

--- a/html/pg_bigm_en-1-2.html
+++ b/html/pg_bigm_en-1-2.html
@@ -516,7 +516,7 @@ ERROR:  out of memory
 </ul>
 
 <hr>
-<div align="right">Copyright (c) 2017-2021, pg_bigm Development Group</div>
+<div align="right">Copyright (c) 2017-2022, pg_bigm Development Group</div>
 <div align="right">Copyright (c) 2012-2016, NTT DATA Corporation</div>
 
 </body>

--- a/html/pg_bigm_en-1-2.html
+++ b/html/pg_bigm_en-1-2.html
@@ -516,6 +516,7 @@ ERROR:  out of memory
 </ul>
 
 <hr>
+<div align="right">Copyright (c) 2017-2019, pg_bigm Development Group</div>
 <div align="right">Copyright (c) 2012-2016, NTT DATA Corporation</div>
 
 </body>

--- a/html/pg_bigm_en-1-2.html
+++ b/html/pg_bigm_en-1-2.html
@@ -114,7 +114,7 @@ For example, x.y is 1.1 and YYYYMMDD is 20131122 if the file of the version 1.1 
 </tr>
 <tr>
   <td>DBMS</td>
-  <td nowrap>PostgreSQL 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 10, 11</td>
+  <td nowrap>PostgreSQL 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 10, 11, 12</td>
 </tr>
 </tbody>
 </table>

--- a/html/pg_bigm_en-1-2.html
+++ b/html/pg_bigm_en-1-2.html
@@ -114,7 +114,7 @@ For example, x.y is 1.1 and YYYYMMDD is 20131122 if the file of the version 1.1 
 </tr>
 <tr>
   <td>DBMS</td>
-  <td nowrap>PostgreSQL 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 10, 11, 12, 13</td>
+  <td nowrap>PostgreSQL 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 10, 11, 12, 13, 14</td>
 </tr>
 </tbody>
 </table>

--- a/html/pg_bigm_en-1-2.html
+++ b/html/pg_bigm_en-1-2.html
@@ -114,7 +114,7 @@ For example, x.y is 1.1 and YYYYMMDD is 20131122 if the file of the version 1.1 
 </tr>
 <tr>
   <td>DBMS</td>
-  <td nowrap>PostgreSQL 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 10</td>
+  <td nowrap>PostgreSQL 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 10, 11</td>
 </tr>
 </tbody>
 </table>

--- a/html/pg_bigm_en-1-2.html
+++ b/html/pg_bigm_en-1-2.html
@@ -376,7 +376,7 @@ This is basically the same behavior as pg_trgm's similarity function.
 </pre>
 
 <p>
-Note that bigm_similarity is NOT case-sensitive, but pg_trgm's similarity function is case-sensitive.
+Note that bigm_similarity IS case-sensitive, but pg_trgm's similarity function is not.
 For example, the similarity of the strings "ABC" and "abc" is 1 in pg_trgm's similarity function but 0 in bigm_similarity.
 </p>
 

--- a/html/pg_bigm_en-1-2.html
+++ b/html/pg_bigm_en-1-2.html
@@ -516,7 +516,7 @@ ERROR:  out of memory
 </ul>
 
 <hr>
-<div align="right">Copyright (c) 2017-2020, pg_bigm Development Group</div>
+<div align="right">Copyright (c) 2017-2021, pg_bigm Development Group</div>
 <div align="right">Copyright (c) 2012-2016, NTT DATA Corporation</div>
 
 </body>

--- a/html/release-1-2.html
+++ b/html/release-1-2.html
@@ -26,7 +26,7 @@
 ALTER EXTENSION pg_bigm UPDATE TO '1.2';
 </pre>
 
-<h2 id="release_note_2020-02-XX">バージョン1.2 (2020-02-XX リリース)</h2>
+<h2 id="release_note_2020-02-28">バージョン1.2 (2020-02-28 リリース)</h2>
 <ul>
 <li><p>PostgreSQL 12以降でビルドすると、コンパイル時に警告が発生する問題を修正しました。(Torikoshi Atsushi, Fujii Masao)</p></li>
 </ul>

--- a/html/release-1-2.html
+++ b/html/release-1-2.html
@@ -47,7 +47,7 @@ ALTER EXTENSION pg_bigm UPDATE TO '1.2';
 </ul>
 
 <hr>
-<div align="right">Copyright (c) 2017-2021, pg_bigm Development Group</div>
+<div align="right">Copyright (c) 2017-2022, pg_bigm Development Group</div>
 <div align="right">Copyright (c) 2012-2016, NTT DATA Corporation</div>
 
 </body>

--- a/html/release-1-2.html
+++ b/html/release-1-2.html
@@ -26,7 +26,7 @@
 ALTER EXTENSION pg_bigm UPDATE TO '1.2';
 </pre>
 
-<h2 id="release_note_2019-10-XX">バージョン1.2 (2019-10-XX リリース)</h2>
+<h2 id="release_note_2019-10-03">バージョン1.2 (2019-10-03 リリース)</h2>
 <ul>
 <li><p>pg_bigm 1.2 をPostgreSQL12以降に対応させました。(Fujii Masao)</p></li>
 </ul>

--- a/html/release-1-2.html
+++ b/html/release-1-2.html
@@ -26,6 +26,11 @@
 ALTER EXTENSION pg_bigm UPDATE TO '1.2';
 </pre>
 
+<h2 id="release_note_2019-10-XX">バージョン1.2 (2019-10-XX リリース)</h2>
+<ul>
+<li><p>pg_bigm 1.2 をPostgreSQL12以降に対応させました。(Fujii Masao)</p></li>
+</ul>
+
 <h2 id="release_note_2016-10-11">バージョン1.2 (2016-10-11 リリース)</h2>
 <ul>
 <li><p>PostgreSQL 9.6で導入されたパラレルクエリにpg_bigmを対応させました。(Fujii Masao)</p></li>

--- a/html/release-1-2.html
+++ b/html/release-1-2.html
@@ -26,6 +26,11 @@
 ALTER EXTENSION pg_bigm UPDATE TO '1.2';
 </pre>
 
+<h2 id="release_note_2020-02-XX">バージョン1.2 (2020-02-XX リリース)</h2>
+<ul>
+<li><p>PostgreSQL 12以降でビルドすると、コンパイル時に警告が発生する問題を修正しました。(Torikoshi Atsushi, Fujii Masao)</p></li>
+</ul>
+
 <h2 id="release_note_2019-10-03">バージョン1.2 (2019-10-03 リリース)</h2>
 <ul>
 <li><p>pg_bigm 1.2 をPostgreSQL12以降に対応させました。(Fujii Masao)</p></li>

--- a/html/release-1-2.html
+++ b/html/release-1-2.html
@@ -47,7 +47,7 @@ ALTER EXTENSION pg_bigm UPDATE TO '1.2';
 </ul>
 
 <hr>
-<div align="right">Copyright (c) 2017-2020, pg_bigm Development Group</div>
+<div align="right">Copyright (c) 2017-2021, pg_bigm Development Group</div>
 <div align="right">Copyright (c) 2012-2016, NTT DATA Corporation</div>
 
 </body>

--- a/html/release-1-2.html
+++ b/html/release-1-2.html
@@ -42,6 +42,7 @@ ALTER EXTENSION pg_bigm UPDATE TO '1.2';
 </ul>
 
 <hr>
+<div align="right">Copyright (c) 2017-2019, pg_bigm Development Group</div>
 <div align="right">Copyright (c) 2012-2016, NTT DATA Corporation</div>
 
 </body>

--- a/html/release-1-2.html
+++ b/html/release-1-2.html
@@ -42,7 +42,7 @@ ALTER EXTENSION pg_bigm UPDATE TO '1.2';
 </ul>
 
 <hr>
-<div align="right">Copyright (c) 2017-2019, pg_bigm Development Group</div>
+<div align="right">Copyright (c) 2017-2020, pg_bigm Development Group</div>
 <div align="right">Copyright (c) 2012-2016, NTT DATA Corporation</div>
 
 </body>

--- a/html/release-1-2.html
+++ b/html/release-1-2.html
@@ -47,7 +47,7 @@ ALTER EXTENSION pg_bigm UPDATE TO '1.2';
 </ul>
 
 <hr>
-<div align="right">Copyright (c) 2017-2022, pg_bigm Development Group</div>
+<div align="right">Copyright (c) 2017-2023, pg_bigm Development Group</div>
 <div align="right">Copyright (c) 2012-2016, NTT DATA Corporation</div>
 
 </body>

--- a/html/release-1-2_en.html
+++ b/html/release-1-2_en.html
@@ -47,7 +47,7 @@ ALTER EXTENSION pg_bigm UPDATE TO '1.2';
 </ul>
 
 <hr>
-<div align="right">Copyright (c) 2017-2021, pg_bigm Development Group</div>
+<div align="right">Copyright (c) 2017-2022, pg_bigm Development Group</div>
 <div align="right">Copyright (c) 2012-2016, NTT DATA Corporation</div>
 
 </body>

--- a/html/release-1-2_en.html
+++ b/html/release-1-2_en.html
@@ -26,7 +26,7 @@
 ALTER EXTENSION pg_bigm UPDATE TO '1.2';
 </pre>
 
-<h2 id="release_note_2019-10-XX">Version 1.2 (released on 2019-10-XX)</h2>
+<h2 id="release_note_2019-10-03">Version 1.2 (released on 2019-10-03)</h2>
 <ul>
 <li><p>Make pg_bigm 1.2 support PostgreSQL 12 or later (Fujii Masao)</p></li>
 </ul>

--- a/html/release-1-2_en.html
+++ b/html/release-1-2_en.html
@@ -26,6 +26,11 @@
 ALTER EXTENSION pg_bigm UPDATE TO '1.2';
 </pre>
 
+<h2 id="release_note_2019-10-XX">Version 1.2 (released on 2019-10-XX)</h2>
+<ul>
+<li><p>Make pg_bigm 1.2 support PostgreSQL 12 or later (Fujii Masao)</p></li>
+</ul>
+
 <h2 id="release_note_2016-10-11">Version 1.2 (released on 2016-10-11)</h2>
 <ul>
 <li><p>Make pg_bigm available for parallel queries that was introduced in PostgreSQL 9.6 (Fujii Masao)</p></li>

--- a/html/release-1-2_en.html
+++ b/html/release-1-2_en.html
@@ -47,7 +47,7 @@ ALTER EXTENSION pg_bigm UPDATE TO '1.2';
 </ul>
 
 <hr>
-<div align="right">Copyright (c) 2017-2020, pg_bigm Development Group</div>
+<div align="right">Copyright (c) 2017-2021, pg_bigm Development Group</div>
 <div align="right">Copyright (c) 2012-2016, NTT DATA Corporation</div>
 
 </body>

--- a/html/release-1-2_en.html
+++ b/html/release-1-2_en.html
@@ -26,7 +26,7 @@
 ALTER EXTENSION pg_bigm UPDATE TO '1.2';
 </pre>
 
-<h2 id="release_note_2020-02-XX">Version 1.2 (released on 2020-02-XX)</h2>
+<h2 id="release_note_2020-02-28">Version 1.2 (released on 2020-02-28)</h2>
 <ul>
 <li><p>Fix compiler warning caused when built with PostgreSQL 12 or later (Torikoshi Atsushi, Fujii Masao)</p></li>
 </ul>

--- a/html/release-1-2_en.html
+++ b/html/release-1-2_en.html
@@ -26,6 +26,11 @@
 ALTER EXTENSION pg_bigm UPDATE TO '1.2';
 </pre>
 
+<h2 id="release_note_2020-02-XX">Version 1.2 (released on 2020-02-XX)</h2>
+<ul>
+<li><p>Fix compiler warning caused when built with PostgreSQL 12 or later (Torikoshi Atsushi, Fujii Masao)</p></li>
+</ul>
+
 <h2 id="release_note_2019-10-03">Version 1.2 (released on 2019-10-03)</h2>
 <ul>
 <li><p>Make pg_bigm 1.2 support PostgreSQL 12 or later (Fujii Masao)</p></li>

--- a/html/release-1-2_en.html
+++ b/html/release-1-2_en.html
@@ -42,6 +42,7 @@ ALTER EXTENSION pg_bigm UPDATE TO '1.2';
 </ul>
 
 <hr>
+<div align="right">Copyright (c) 2017-2019, pg_bigm Development Group</div>
 <div align="right">Copyright (c) 2012-2016, NTT DATA Corporation</div>
 
 </body>

--- a/html/release-1-2_en.html
+++ b/html/release-1-2_en.html
@@ -42,7 +42,7 @@ ALTER EXTENSION pg_bigm UPDATE TO '1.2';
 </ul>
 
 <hr>
-<div align="right">Copyright (c) 2017-2019, pg_bigm Development Group</div>
+<div align="right">Copyright (c) 2017-2020, pg_bigm Development Group</div>
 <div align="right">Copyright (c) 2012-2016, NTT DATA Corporation</div>
 
 </body>

--- a/html/release-1-2_en.html
+++ b/html/release-1-2_en.html
@@ -47,7 +47,7 @@ ALTER EXTENSION pg_bigm UPDATE TO '1.2';
 </ul>
 
 <hr>
-<div align="right">Copyright (c) 2017-2022, pg_bigm Development Group</div>
+<div align="right">Copyright (c) 2017-2023, pg_bigm Development Group</div>
 <div align="right">Copyright (c) 2012-2016, NTT DATA Corporation</div>
 
 </body>

--- a/sql/pg_bigm.sql
+++ b/sql/pg_bigm.sql
@@ -41,7 +41,11 @@ CREATE INDEX test_bigm_idx ON test_bigm
 \copy test_bigm from 'data/bigm.csv' with csv
 
 -- tests pg_gin_pending_stats
-SELECT * FROM pg_gin_pending_stats('test_bigm_idx');
+
+-- exclude pages column from the return values of only this call of
+-- pg_gin_pending_stats(), in order to stabilize the result of
+-- this regression test whatever block size is used in PostgreSQL server.
+SELECT tuples FROM pg_gin_pending_stats('test_bigm_idx');
 VACUUM;
 SELECT * FROM pg_gin_pending_stats('test_bigm_idx');
 SELECT * FROM pg_gin_pending_stats('test_bigm');

--- a/sql/pg_bigm.sql
+++ b/sql/pg_bigm.sql
@@ -9,6 +9,9 @@ SET pg_bigm.enable_recheck = on;
 SET pg_bigm.gin_key_limit = 0;
 SET pg_bigm.similarity_limit = 0.02;
 
+-- reduce noise
+SET extra_float_digits TO 0;
+
 -- tests for pg_bigm.last_update
 SHOW pg_bigm.last_update;
 SET pg_bigm.last_update = '2013.09.18';

--- a/sql/pg_bigm_ja.sql
+++ b/sql/pg_bigm_ja.sql
@@ -9,6 +9,9 @@ SET pg_bigm.enable_recheck = on;
 SET pg_bigm.gin_key_limit = 0;
 SET pg_bigm.similarity_limit = 0.02;
 
+-- reduce noise
+SET extra_float_digits TO 0;
+
 -- tests for likequery
 SELECT likequery('ポスグレの全文検索');
 SELECT likequery('pg_bigmは検索性能を200%向上させました');


### PR DESCRIPTION
The RPMs of pg_bigm-1.2-2020 for PostgreSQL 12.0
are released.
