### PR TITLE
Fix compilation error in pg_bigm caused by PostgreSQL 16dev update

### DIFF
--- a/bigm_op.c
+++ b/bigm_op.c
@@ -20,6 +20,9 @@
 #include "catalog/pg_type.h"
 #include "tsearch/ts_locale.h"
 #include "utils/array.h"
+#if PG_VERSION_NUM >= 160000
+#include "utils/guc.h"
+#endif /* PG_VERSION_NUM */
 #include "utils/memutils.h"
 
 PG_MODULE_MAGIC;


### PR DESCRIPTION
Commit 0a20ff54f5 in PostgreSQL 16dev caused pg_bigm to fail compilation due to a missing header file. This commit fixes the issue by updating bigm_op.c to include utils/guc.h. This change ensures that pg_bigm is compatible with PostgreSQL 16dev,
allowing for continued use and development of the extension.

Back-patch to pg_bigm 1.2.