### PR TITLE
Update README.md to point to GitHub Pages documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,22 @@ This module allows a user to create **2-gram** (bigram) index for faster full te
 
 pg_bigm is released under the [PostgreSQL License](https://opensource.org/licenses/postgresql), a liberal Open Source license, similar to the BSD or MIT licenses.
 
-For more information look at [the official pg_bigm web site](https://pgbigm.osdn.jp/index_en.html).
-
 ## Test Status
 [![Build Status](https://travis-ci.com/pgbigm/pg_bigm.svg?branch=master)](https://travis-ci.com/github/pgbigm/pg_bigm)
+
+## Documentation
+### English
+* [Release 1.2](https://pgbigm.github.io/pg_bigm/pg_bigm_en-1-2.html)
+* [Release 1.1](https://pgbigm.github.io/pg_bigm/pg_bigm_en-1-1.html)
+* [Release 1.0](https://pgbigm.github.io/pg_bigm/pg_bigm_en.html)
+
+### 日本語
+* [リリース1.2](https://pgbigm.github.io/pg_bigm/pg_bigm-1-2.html)
+* [リリース1.1](https://pgbigm.github.io/pg_bigm/pg_bigm-1-1.html)
+* [リリース1.0](https://pgbigm.github.io/pg_bigm/pg_bigm.html)
+
+*****
+
+Copyright (c) 2017-2023, pg_bigm Development Group
+
+Copyright (c) 2012-2016, NTT DATA Corporation


### PR DESCRIPTION
This commit updates the README.md file to include a link to the documentation deployed at GitHub Pages, making it easier for users to access up-to-date documentation for pg_bigm. Additionally, it removes a description that suggests an obsolete official site for pg_bigm, reducing confusion caused by outdated information. Furthermore, this commit adds copyright information to the README.md file to ensure proper attribution for the project.

These changes improve the clarity and accuracy of the project's documentation and information.