### PR TITLE
Fix pg_bigm GitHub Actions test failure by installing missing readline library.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,10 @@ jobs:
       PGBRANCH: ${{ matrix.pgbranch }}
     steps:
     - uses: actions/checkout@v4
+    - name: apt
+      run: |
+        sudo apt-get --yes update
+        sudo apt-get --yes install libreadline-dev
     - name: set_env
       run: |
         echo "PGHOME=${HOME}/${PGBRANCH}" >> $GITHUB_ENV


### PR DESCRIPTION
The GitHub Actions test for pg_bigm failed because PostgreSQL compilation could not find the readline library. This commit updates test.yml to ensure readline is installed, allowing the test to run successfully.