### PR TITLE
Fix pg_bigm compilation error due to PostgreSQL 18dev update.

### DIFF
--- a/bigm.h
+++ b/bigm.h
@@ -87,6 +87,10 @@ typedef struct
 #define GETARR(x)		( (bigm *)( (char*)x + VARHDRSZ ) )
 #define ARRNELEM(x) ( ( VARSIZE(x) - VARHDRSZ )/sizeof(bigm) )
 
+#if PG_VERSION_NUM >= 180000
+extern int t_isspace(const char *ptr);
+#endif
+
 extern BIGM *generate_bigm(char *str, int slen);
 extern BIGM *generate_wildcard_bigm(const char *str, int slen, bool *removeDups);
 

--- a/bigm_op.c
+++ b/bigm_op.c
@@ -155,6 +155,30 @@ unique_array(bigm *a, int len)
 	return curend + 1 - a;
 }
 
+#if PG_VERSION_NUM >= 180000
+/*
+ * This function is equivalent to isspace() but supports multibyte
+ * characters and encoding. It was part of PostgreSQL 17 and earlier
+ * but was removed in commit d3aad4ac57c. This version is copied
+ * from PostgreSQL 17.
+ */
+int
+t_isspace(const char *ptr)
+{
+#define WC_BUF_LEN  3
+	int			clen = pg_mblen(ptr);
+	wchar_t		character[WC_BUF_LEN];
+	pg_locale_t mylocale = 0;	/* TODO */
+
+	if (clen == 1 || database_ctype_is_c)
+		return isspace(TOUCHAR(ptr));
+
+	char2wchar(character, WC_BUF_LEN, ptr, clen, mylocale);
+
+	return iswspace((wint_t) character[0]);
+}
+#endif
+
 #define iswordchr(c)	(!t_isspace(c))
 
 /*


### PR DESCRIPTION
Commit d3aad4ac57c removed t_isspace() from PostgreSQL, but pg_bigm still relies on it, causing a compilation failure on PostgreSQL 18dev. This commit restores t_isspace() from PostgreSQL 17 to maintain compatibility with PostgreSQL 18dev.