### PR TITLE
Fix array-bound-read in make_bigram().

### DIFF
--- a/bigm_op.c
+++ b/bigm_op.c
@@ -224,6 +224,8 @@ make_bigrams(bigm *bptr, char *str, int bytelen, int charlen)
 			bptr++;
 
 			lenfirst = lenlast;
+			if ((ptr - str) + lenfirst >= bytelen)
+				break;
 			lenlast = pg_mblen(ptr + lenfirst);
 		}
 	}


### PR DESCRIPTION
When running pg_bigm's test `sql/pg_bigm_ja.sql` with memory sanitization, the following warning was report:

```
==4725==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x5595ec37c229 in pg_utf_mblen postgres/src/common/wchar.c:573:18
    #1 0x5595e7d0edc1 in pg_mblen postgres/src/backend/utils/mb/mbutils.c:1026:9
    #2 0x7f596e0bb6c2 in make_bigrams pg_bigm/bigm_op.c:227:14
    #3 0x7f596e0bbd9d in generate_wildcard_bigm pg_bigm/bigm_op.c:528:10
    #4 0x7f596e0ba0a1 in gin_extract_query_bigm pg_bigm/bigm_gin.c:133:10
    #5 0x5595e7cf874d in FunctionCall7Coll postgres/src/backend/utils/fmgr/fmgr.c:1279:11
    #6 0x5595e788a701 in gincost_pattern postgres/src/backend/utils/adt/selfuncs.c:7225:2
    #7 0x5595e7886f30 in gincost_opexpr postgres/src/backend/utils/adt/selfuncs.c:7313:9
    #8 0x5595e7886f30 in gincostestimate postgres/src/backend/utils/adt/selfuncs.c:7596:21
    #9 0x5595e735995a in cost_index postgres/src/backend/optimizer/path/costsize.c:590:2
    #10 0x5595e73fe85d in create_index_path postgres/src/backend/optimizer/util/pathnode.c:1031:2
    #11 0x5595e73777a3 in build_index_paths postgres/src/backend/optimizer/path/indxpath.c:1010:11
    #12 0x5595e7371e03 in get_index_paths postgres/src/backend/optimizer/path/indxpath.c:728:15
    #13 0x5595e7371119 in create_index_paths postgres/src/backend/optimizer/path/indxpath.c:280:3
    #14 0x5595e7356e4c in set_plain_rel_pathlist postgres/src/backend/optimizer/path/allpaths.c:786:2
    #15 0x5595e7356ac6 in set_rel_pathlist postgres/src/backend/optimizer/path/allpaths.c:502:6
    #16 0x5595e734d500 in set_base_rel_pathlists postgres/src/backend/optimizer/path/allpaths.c:354:3
    #17 0x5595e734d500 in make_one_rel postgres/src/backend/optimizer/path/allpaths.c:224:2
    #18 0x5595e73ac565 in query_planner postgres/src/backend/optimizer/plan/planmain.c:278:14
    #19 0x5595e73b28b0 in grouping_planner postgres/src/backend/optimizer/plan/planner.c:1506:17
    #20 0x5595e73af80e in subquery_planner postgres/src/backend/optimizer/plan/planner.c:1075:2
    #21 0x5595e73ac95c in standard_planner postgres/src/backend/optimizer/plan/planner.c:413:9
    #22 0x5595e73ac6d8 in planner postgres/src/backend/optimizer/plan/planner.c:281:12
    #23 0x5595e76a61af in pg_plan_query postgres/src/backend/tcop/postgres.c:919:9
    #24 0x5595e70b320d in ExplainOneQuery postgres/src/backend/commands/explain.c:413:10
    #25 0x5595e70b2a0b in ExplainQuery postgres/src/backend/commands/explain.c:297:4
    #26 0x5595e76b3687 in standard_ProcessUtility postgres/src/backend/tcop/utility.c:892:4
    #27 0x5595e76b313c in ProcessUtility postgres/src/backend/tcop/utility.c:543:4
    #28 0x5595e76b287d in PortalRunUtility postgres/src/backend/tcop/pquery.c:1181:2
    #29 0x5595e76b0d78 in FillPortalStore postgres/src/backend/tcop/pquery.c:1054:4
    #30 0x5595e76b077c in PortalRun postgres/src/backend/tcop/pquery.c:786:6
    #31 0x5595e76ae40c in exec_simple_query postgres/src/backend/tcop/postgres.c:1289:10
    #32 0x5595e76a9fbf in PostgresMain postgres/src/backend/tcop/postgres.c
    #33 0x5595e75070cc in BackendRun postgres/src/backend/postmaster/postmaster.c:4506:2
    #34 0x5595e75039d3 in BackendStartup postgres/src/backend/postmaster/postmaster.c:4234:3
    #35 0x5595e75039d3 in ServerLoop postgres/src/backend/postmaster/postmaster.c:1807:6
    #36 0x5595e74fe8d2 in PostmasterMain postgres/src/backend/postmaster/postmaster.c:1491:11
    #37 0x5595e6e878b3 in main postgres/src/backend/main/main.c:200:3

SUMMARY: MemorySanitizer: use-of-uninitialized-value postgres/src/common/wchar.c:573:18 in pg_utf_mblen
```

IIUC, this happens because of `make_bigram()` reading beyond the end of input string when looking for next multibyte character via `pg_mblen()`. To avoid that, this commit checks to see the end of string is reached and exit before invoking `pg_mblen()`.