### PR TITLE
Fix inconsistent index scan behavior due to char signedness on different architectures.

### DIFF
--- a/bigm.h
+++ b/bigm.h
@@ -46,6 +46,13 @@ typedef struct
 
 #define BIGMSIZE	sizeof(bigm)
 
+#if PG_VERSION_NUM >= 180000
+/*
+ * Database clusters maintain their char signedness information since 18,
+ * therefore the CMPBIGM() function implementation is chosen at runtime.
+ */
+extern int	(*CMPBIGM) (const bigm *a, const bigm *b);
+#else
 static inline int
 bigmstrcmp(char *arg1, int len1, char *arg2, int len2)
 {
@@ -66,6 +73,7 @@ bigmstrcmp(char *arg1, int len1, char *arg2, int len2)
 }
 
 #define CMPBIGM(a,b) ( bigmstrcmp(((bigm *)a)->str, ((bigm *)a)->bytelen, ((bigm *)b)->str, ((bigm *)b)->bytelen) )
+#endif
 
 #define CPBIGM(bptr, s, len) do {		\
 	Assert(len <= 8);				\


### PR DESCRIPTION
GIN indexes utilizing pg_bigm's opclasses store sorted bigrams within index tuples. When comparing and sorting each bigram, pg_bigm treats each character as a 'char[3]' type in C. However, the char type in C can be interpreted as either signed char or unsigned char, depending on the platform, if the signedness is not explicitly specified. Consequently, as reported in issue #15, during replication between different CPU architectures, there was an issue where index scans on standby servers could not locate matching index tuples due to the differing treatment of character signedness. This problem can also happen in cases where the database cluster was initialized on one platform and later migrated to a different platform.

This change introduces comparison functions for bigm that explicitly handle signed char and unsigned char. The appropriate comparison function will be dynamically selected based on the character signedness stored in the control file. Therefore, upgraded clusters can utilize the indexes without rebuilding, provided the cluster upgrade occurs on platforms with the same character signedness as the original cluster initialization.

This commit is inspired by pg_trgm's change: dfd8e6c.

Issue #15