### PR TITLE
Add PostgreSQL 19 compatibility

### DIFF
--- a/bigm_op.c
+++ b/bigm_op.c
@@ -157,22 +157,34 @@ unique_array(bigm *a, int len)
 
 #if PG_VERSION_NUM >= 180000
 /*
- * This function is equivalent to isspace() but supports multibyte
- * characters and encoding. It was part of PostgreSQL 17 and earlier
- * but was removed in commit d3aad4ac57c. This version is copied
- * from PostgreSQL 17.
+ * Equivalent of isspace() with multibyte/encoding support.
+ *
+ * The original t_isspace() was removed from PostgreSQL in commit
+ * d3aad4ac57c (PG18). On PG18 we use the implementation copied from
+ * PG17. On PG19 the global `database_ctype_is_c` and the exported
+ * `char2wchar()` are gone, so we use the new pg_locale.h API
+ * (pg_database_locale() / pg_iswspace()) the same way PG19's own
+ * src/backend/tsearch/ts_locale.c does for t_isalnum / t_isalpha.
  */
 int
 t_isspace(const char *ptr)
 {
+#if PG_VERSION_NUM >= 190000
+	int			clen = pg_mblen(ptr);
+	pg_wchar	wstr[2];
+	pg_locale_t mylocale = pg_database_locale();
+
+	if (clen == 1 || mylocale->ctype_is_c)
+		return isspace(TOUCHAR(ptr));
+
+	pg_mb2wchar_with_len(ptr, wstr, clen);
+
+	return pg_iswspace(wstr[0], mylocale);
+#else
 #define WC_BUF_LEN  3
 	int			clen = pg_mblen(ptr);
 	wchar_t		character[WC_BUF_LEN];
-#if PG_VERSION_NUM >= 190000
-	locale_t mylocale = 0;	/* TODO */
-#else
 	pg_locale_t mylocale = 0;	/* TODO */
-#endif	/* PG_VERSION_NUM >= 190000 */
 
 	if (clen == 1 || database_ctype_is_c)
 		return isspace(TOUCHAR(ptr));
@@ -180,6 +192,7 @@ t_isspace(const char *ptr)
 	char2wchar(character, WC_BUF_LEN, ptr, clen, mylocale);
 
 	return iswspace((wint_t) character[0]);
+#endif	/* PG_VERSION_NUM >= 190000 */
 }
 #endif	/* PG_VERSION_NUM >= 180000 */
 

--- a/expected/pg_bigm_2.out
+++ b/expected/pg_bigm_2.out
@@ -1,0 +1,695 @@
+CREATE EXTENSION pg_bigm;
+\pset null '(null)'
+SET standard_conforming_strings = on;
+SET escape_string_warning = off;
+ERROR:  unrecognized configuration parameter "escape_string_warning"
+SET enable_seqscan = off;
+SET pg_bigm.enable_recheck = on;
+SET pg_bigm.gin_key_limit = 0;
+SET pg_bigm.similarity_limit = 0.02;
+-- reduce noise
+SET extra_float_digits TO 0;
+-- tests for pg_bigm.last_update
+SHOW pg_bigm.last_update;
+ pg_bigm.last_update 
+---------------------
+ 2025.09.03
+(1 row)
+
+SET pg_bigm.last_update = '2013.09.18';
+ERROR:  parameter "pg_bigm.last_update" cannot be changed
+-- tests for likequery
+SELECT likequery(NULL);
+ likequery 
+-----------
+ (null)
+(1 row)
+
+SELECT likequery('');
+ likequery 
+-----------
+ (null)
+(1 row)
+
+SELECT likequery('  ');
+ likequery 
+-----------
+ %  %
+(1 row)
+
+SELECT likequery('aBc023#*^&');
+  likequery   
+--------------
+ %aBc023#*^&%
+(1 row)
+
+SELECT likequery('\_%');
+ likequery 
+-----------
+ %\\\_\%%
+(1 row)
+
+-- tests for show_bigm
+SELECT show_bigm(NULL);
+ show_bigm 
+-----------
+ (null)
+(1 row)
+
+SELECT show_bigm('');
+ show_bigm 
+-----------
+ {}
+(1 row)
+
+SELECT show_bigm('i');
+  show_bigm  
+-------------
+ {" i","i "}
+(1 row)
+
+SELECT show_bigm('ab');
+   show_bigm    
+----------------
+ {" a",ab,"b "}
+(1 row)
+
+SELECT show_bigm('aBc023$&^');
+              show_bigm              
+-------------------------------------
+ {" a",$&,&^,02,23,3$,Bc,"^ ",aB,c0}
+(1 row)
+
+SELECT show_bigm('\_%');
+       show_bigm       
+-----------------------
+ {" \\","% ","\\_",_%}
+(1 row)
+
+SELECT show_bigm('  ');
+ show_bigm 
+-----------
+ {}
+(1 row)
+
+SELECT show_bigm('pg_bigm improves performance by 200%');
+                                                            show_bigm                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ {" 2"," b"," i"," p","% ",0%,00,20,_b,an,bi,by,ce,"e ",er,es,fo,g_,gm,ig,im,"m ",ma,mp,nc,or,ov,pe,pg,pr,rf,rm,ro,"s ",ve,"y "}
+(1 row)
+
+-- tests for creation of full-text search index
+CREATE TABLE test_bigm (col1 text, col2 text);
+CREATE INDEX test_bigm_idx ON test_bigm
+			 USING gin (col1 gin_bigm_ops, col2 gin_bigm_ops);
+\copy test_bigm from 'data/bigm.csv' with csv
+-- tests pg_gin_pending_stats
+-- exclude pages column from the return values of only this call of
+-- pg_gin_pending_stats(), in order to stabilize the result of
+-- this regression test whatever block size is used in PostgreSQL server.
+SELECT tuples FROM pg_gin_pending_stats('test_bigm_idx');
+ tuples 
+--------
+    249
+(1 row)
+
+VACUUM;
+SELECT * FROM pg_gin_pending_stats('test_bigm_idx');
+ pages | tuples 
+-------+--------
+     0 |      0
+(1 row)
+
+SELECT * FROM pg_gin_pending_stats('test_bigm');
+ERROR:  relation "test_bigm" is not a GIN index
+CREATE INDEX test_bigm_btree ON test_bigm USING btree (col2);
+SELECT * FROM pg_gin_pending_stats('test_bigm_btree');
+ERROR:  relation "test_bigm_btree" is not a GIN index
+DROP INDEX test_bigm_btree;
+-- tests for full-text search
+EXPLAIN (COSTS off) SELECT * FROM test_bigm WHERE col1 LIKE likequery('a');
+                QUERY PLAN                 
+-------------------------------------------
+ Bitmap Heap Scan on test_bigm
+   Recheck Cond: (col1 ~~ '%a%'::text)
+   ->  Bitmap Index Scan on test_bigm_idx
+         Index Cond: (col1 ~~ '%a%'::text)
+(4 rows)
+
+EXPLAIN (COSTS off) SELECT * FROM test_bigm WHERE col1 LIKE likequery('am');
+                 QUERY PLAN                 
+--------------------------------------------
+ Bitmap Heap Scan on test_bigm
+   Recheck Cond: (col1 ~~ '%am%'::text)
+   ->  Bitmap Index Scan on test_bigm_idx
+         Index Cond: (col1 ~~ '%am%'::text)
+(4 rows)
+
+EXPLAIN (COSTS off) SELECT * FROM test_bigm WHERE col1 LIKE likequery('XML');
+                 QUERY PLAN                  
+---------------------------------------------
+ Bitmap Heap Scan on test_bigm
+   Recheck Cond: (col1 ~~ '%XML%'::text)
+   ->  Bitmap Index Scan on test_bigm_idx
+         Index Cond: (col1 ~~ '%XML%'::text)
+(4 rows)
+
+EXPLAIN (COSTS off) SELECT * FROM test_bigm WHERE col1 LIKE likequery('bigm');
+                  QUERY PLAN                  
+----------------------------------------------
+ Bitmap Heap Scan on test_bigm
+   Recheck Cond: (col1 ~~ '%bigm%'::text)
+   ->  Bitmap Index Scan on test_bigm_idx
+         Index Cond: (col1 ~~ '%bigm%'::text)
+(4 rows)
+
+SELECT col1 FROM test_bigm WHERE col1 LIKE likequery(NULL);
+ col1 
+------
+(0 rows)
+
+SELECT col1 FROM test_bigm WHERE col1 LIKE likequery('');
+ col1 
+------
+(0 rows)
+
+SELECT col1 FROM test_bigm WHERE col1 LIKE likequery('%');
+                             col1                              
+---------------------------------------------------------------
+ Sets the similarity threshold used by the =% operator.
+ pg_bigm has improved the full text search performance by 200%
+(2 rows)
+
+SELECT col1 FROM test_bigm WHERE col1 LIKE likequery('\');
+                              col1                              
+----------------------------------------------------------------
+ Sets whether "\'" is allowed in string literals.
+ \dx displays list of installed extensions
+ \w FILE outputs the current query buffer to the file specified
+(3 rows)
+
+SELECT col1 FROM test_bigm WHERE col1 LIKE likequery('_');
+                                      col1                                      
+--------------------------------------------------------------------------------
+ Allows archiving of WAL files using archive_command.
+ Sets the minimum concurrent open transactions before performing commit_delay.
+ Shows the last update date of pg_bigm.
+ Sets the size reserved for pg_stat_activity.query, in bytes.
+ pg_trgm -  Tool that provides 3-gram full text search capability in PostgreSQL
+ pg_bigm -  Tool that provides 2-gram full text search capability in PostgreSQL
+ pg_bigm has improved the full text search performance by 200%
+(7 rows)
+
+SELECT col1 FROM test_bigm WHERE col1 LIKE likequery('\dx');
+                   col1                    
+-------------------------------------------
+ \dx displays list of installed extensions
+(1 row)
+
+SELECT col1 FROM test_bigm WHERE col1 LIKE likequery('pg_bigm');
+                                      col1                                      
+--------------------------------------------------------------------------------
+ Shows the last update date of pg_bigm.
+ pg_bigm -  Tool that provides 2-gram full text search capability in PostgreSQL
+ pg_bigm has improved the full text search performance by 200%
+(3 rows)
+
+SELECT col1 FROM test_bigm WHERE col1 LIKE likequery('200%');
+                             col1                              
+---------------------------------------------------------------
+ pg_bigm has improved the full text search performance by 200%
+(1 row)
+
+SELECT col1 FROM test_bigm WHERE col1 LIKE likequery('  ');
+                                      col1                                      
+--------------------------------------------------------------------------------
+ pg_trgm -  Tool that provides 3-gram full text search capability in PostgreSQL
+ pg_bigm -  Tool that provides 2-gram full text search capability in PostgreSQL
+(2 rows)
+
+SELECT col1 FROM test_bigm WHERE col1 LIKE likequery('Y');
+                               col1                               
+------------------------------------------------------------------
+ Generates debugging output for LISTEN and NOTIFY.
+ You can create an index for full text search by using GIN index.
+ You will get into deep trouble for staying out late
+(3 rows)
+
+SELECT col1 FROM test_bigm WHERE col1 LIKE likequery('pi');
+                             col1                             
+--------------------------------------------------------------
+ Vacuum cost amount available before napping, for autovacuum.
+ Vacuum cost amount available before napping.
+(2 rows)
+
+SELECT col1 FROM test_bigm WHERE col1 LIKE likequery('GIN');
+                                     col1                                     
+------------------------------------------------------------------------------
+ Sets the maximum allowed result for exact search by GIN.
+ Sets the maximum number of bi-gram keys allowed to use for GIN index search.
+ You can create an index for full text search by using GIN index.
+(3 rows)
+
+SELECT col1 FROM test_bigm WHERE col1 LIKE likequery('gin');
+                            col1                            
+------------------------------------------------------------
+ Generates debugging output for LISTEN and NOTIFY.
+ Enables logging of recovery-related debugging information.
+(2 rows)
+
+SELECT col1 FROM test_bigm WHERE col1 LIKE likequery('Tool');
+                                      col1                                      
+--------------------------------------------------------------------------------
+ pg_trgm -  Tool that provides 3-gram full text search capability in PostgreSQL
+ pg_bigm -  Tool that provides 2-gram full text search capability in PostgreSQL
+(2 rows)
+
+SELECT col1 FROM test_bigm WHERE col1 LIKE likequery('performance');
+                             col1                              
+---------------------------------------------------------------
+ Writes executor performance statistics to the server log.
+ Writes parser performance statistics to the server log.
+ Writes planner performance statistics to the server log.
+ Writes cumulative performance statistics to the server log.
+ pg_bigm has improved the full text search performance by 200%
+(5 rows)
+
+-- check that the search results don't change if enable_recheck is disabled
+-- in order to check that index full search is NOT executed
+SET pg_bigm.enable_recheck = off;
+SELECT col1 FROM test_bigm WHERE col1 LIKE likequery('Y');
+                               col1                               
+------------------------------------------------------------------
+ Generates debugging output for LISTEN and NOTIFY.
+ You can create an index for full text search by using GIN index.
+ You will get into deep trouble for staying out late
+(3 rows)
+
+SELECT col1 FROM test_bigm WHERE col1 LIKE likequery('pi');
+                             col1                             
+--------------------------------------------------------------
+ Vacuum cost amount available before napping, for autovacuum.
+ Vacuum cost amount available before napping.
+(2 rows)
+
+SET pg_bigm.enable_recheck = on;
+EXPLAIN (COSTS off) SELECT col1 FROM test_bigm WHERE col1 LIKE '%bigm%';
+                  QUERY PLAN                  
+----------------------------------------------
+ Bitmap Heap Scan on test_bigm
+   Recheck Cond: (col1 ~~ '%bigm%'::text)
+   ->  Bitmap Index Scan on test_bigm_idx
+         Index Cond: (col1 ~~ '%bigm%'::text)
+(4 rows)
+
+SELECT col1 FROM test_bigm WHERE col1 LIKE '%Tool%';
+                                      col1                                      
+--------------------------------------------------------------------------------
+ pg_trgm -  Tool that provides 3-gram full text search capability in PostgreSQL
+ pg_bigm -  Tool that provides 2-gram full text search capability in PostgreSQL
+(2 rows)
+
+EXPLAIN (COSTS off) SELECT col1 FROM test_bigm WHERE col1 LIKE '%\%';
+                QUERY PLAN                 
+-------------------------------------------
+ Bitmap Heap Scan on test_bigm
+   Recheck Cond: (col1 ~~ '%\%'::text)
+   ->  Bitmap Index Scan on test_bigm_idx
+         Index Cond: (col1 ~~ '%\%'::text)
+(4 rows)
+
+SELECT col1 FROM test_bigm WHERE col1 LIKE '%\%';
+                             col1                              
+---------------------------------------------------------------
+ Sets the similarity threshold used by the =% operator.
+ pg_bigm has improved the full text search performance by 200%
+(2 rows)
+
+EXPLAIN (COSTS off) SELECT col1 FROM test_bigm WHERE col1 LIKE 'pg\___gm%';
+                   QUERY PLAN                    
+-------------------------------------------------
+ Bitmap Heap Scan on test_bigm
+   Recheck Cond: (col1 ~~ 'pg\___gm%'::text)
+   ->  Bitmap Index Scan on test_bigm_idx
+         Index Cond: (col1 ~~ 'pg\___gm%'::text)
+(4 rows)
+
+SELECT col1 FROM test_bigm WHERE col1 LIKE 'pg\___gm%';
+                                      col1                                      
+--------------------------------------------------------------------------------
+ pg_trgm -  Tool that provides 3-gram full text search capability in PostgreSQL
+ pg_bigm -  Tool that provides 2-gram full text search capability in PostgreSQL
+ pg_bigm has improved the full text search performance by 200%
+(3 rows)
+
+-- tests for pg_bigm.enable_recheck
+SELECT col1 FROM test_bigm WHERE col1 LIKE likequery('trial');
+         col1         
+----------------------
+ He is awaiting trial
+(1 row)
+
+SET pg_bigm.enable_recheck = off;
+SELECT col1 FROM test_bigm WHERE col1 LIKE likequery('trial');
+                                                          col1                                                           
+-------------------------------------------------------------------------------------------------------------------------
+ Whether to defer a read-only serializable transaction until it can be executed with no possible serialization failures.
+ He is awaiting trial
+ It was a trivial mistake
+(3 rows)
+
+-- tests for pg_bigm.gin_key_limit
+SELECT count(*) FROM test_bigm WHERE col1 LIKE likequery('she tore');
+ count 
+-------
+     2
+(1 row)
+
+SET pg_bigm.gin_key_limit = 6;
+SELECT count(*) FROM test_bigm WHERE col1 LIKE likequery('she tore');
+ count 
+-------
+     5
+(1 row)
+
+SET pg_bigm.gin_key_limit = 5;
+SELECT count(*) FROM test_bigm WHERE col1 LIKE likequery('she tore');
+ count 
+-------
+    30
+(1 row)
+
+SET pg_bigm.gin_key_limit = 4;
+SELECT count(*) FROM test_bigm WHERE col1 LIKE likequery('she tore');
+ count 
+-------
+    70
+(1 row)
+
+SET pg_bigm.gin_key_limit = 3;
+SELECT count(*) FROM test_bigm WHERE col1 LIKE likequery('she tore');
+ count 
+-------
+   164
+(1 row)
+
+SET pg_bigm.gin_key_limit = 2;
+SELECT count(*) FROM test_bigm WHERE col1 LIKE likequery('she tore');
+ count 
+-------
+   188
+(1 row)
+
+SET pg_bigm.gin_key_limit = 1;
+SELECT count(*) FROM test_bigm WHERE col1 LIKE likequery('she tore');
+ count 
+-------
+   199
+(1 row)
+
+SET pg_bigm.enable_recheck = on;
+SET pg_bigm.gin_key_limit = 0;
+-- tests with standard_conforming_strings disabled
+SET standard_conforming_strings = off;
+ERROR:  non-standard string literals are not supported
+SELECT likequery('\\_%');
+ likequery  
+------------
+ %\\\\\_\%%
+(1 row)
+
+SELECT show_bigm('\\_%');
+          show_bigm           
+------------------------------
+ {" \\","% ","\\\\","\\_",_%}
+(1 row)
+
+SELECT col1 FROM test_bigm WHERE col1 LIKE likequery('\\');
+ col1 
+------
+(0 rows)
+
+SELECT col1 FROM test_bigm WHERE col1 LIKE likequery('\\dx');
+ col1 
+------
+(0 rows)
+
+SELECT col1 FROM test_bigm WHERE col1 LIKE likequery('200%');
+                             col1                              
+---------------------------------------------------------------
+ pg_bigm has improved the full text search performance by 200%
+(1 row)
+
+-- tests for full text search with multi-column index
+-- keyword exists only in col1. Query on col2 must not return any rows.
+EXPLAIN (COSTS off) SELECT * FROM test_bigm WHERE col2 LIKE likequery('queries');
+                   QUERY PLAN                    
+-------------------------------------------------
+ Bitmap Heap Scan on test_bigm
+   Recheck Cond: (col2 ~~ '%queries%'::text)
+   ->  Bitmap Index Scan on test_bigm_idx
+         Index Cond: (col2 ~~ '%queries%'::text)
+(4 rows)
+
+SELECT * FROM test_bigm WHERE col2 LIKE likequery('queries');
+ col1 | col2 
+------+------
+(0 rows)
+
+-- keyword exists only in col2. All rows with keyword in col2 are returned.
+EXPLAIN (COSTS off) SELECT * FROM test_bigm WHERE col2 LIKE likequery('meta');
+                  QUERY PLAN                  
+----------------------------------------------
+ Bitmap Heap Scan on test_bigm
+   Recheck Cond: (col2 ~~ '%meta%'::text)
+   ->  Bitmap Index Scan on test_bigm_idx
+         Index Cond: (col2 ~~ '%meta%'::text)
+(4 rows)
+
+SELECT * FROM test_bigm WHERE col2 LIKE likequery('meta');
+                              col1                              |     col2     
+----------------------------------------------------------------+--------------
+ \dx displays list of installed extensions                      | meta command
+ \w FILE outputs the current query buffer to the file specified | meta command
+(2 rows)
+
+-- keyword exists in both columns. Query on col1 must not return rows with keyword in col2 only.
+EXPLAIN (COSTS off) SELECT * FROM test_bigm WHERE col1 LIKE likequery('bigm');
+                  QUERY PLAN                  
+----------------------------------------------
+ Bitmap Heap Scan on test_bigm
+   Recheck Cond: (col1 ~~ '%bigm%'::text)
+   ->  Bitmap Index Scan on test_bigm_idx
+         Index Cond: (col1 ~~ '%bigm%'::text)
+(4 rows)
+
+SELECT * FROM test_bigm WHERE col1 LIKE likequery('bigm');
+                                      col1                                      |        col2         
+--------------------------------------------------------------------------------+---------------------
+ Shows the last update date of pg_bigm.                                         | pg_bigm.last_update
+ pg_bigm -  Tool that provides 2-gram full text search capability in PostgreSQL | pg_bigm
+ pg_bigm has improved the full text search performance by 200%                  | pg_bigm performance
+(3 rows)
+
+-- tests for bigm_similarity
+SELECT bigm_similarity('wow', NULL);
+ bigm_similarity 
+-----------------
+          (null)
+(1 row)
+
+SELECT bigm_similarity('wow', '');
+ bigm_similarity 
+-----------------
+               0
+(1 row)
+
+SELECT bigm_similarity('wow', 'WOWa ');
+ bigm_similarity 
+-----------------
+               0
+(1 row)
+
+SELECT bigm_similarity('wow', ' WOW ');
+ bigm_similarity 
+-----------------
+               0
+(1 row)
+
+SELECT bigm_similarity('wow', ' wow ');
+ bigm_similarity 
+-----------------
+               1
+(1 row)
+
+SELECT bigm_similarity('---', '####---');
+ bigm_similarity 
+-----------------
+             0.4
+(1 row)
+
+-- tests for text similarity serach
+EXPLAIN (COSTS off) SELECT * FROM test_bigm WHERE col1 =% 'a';
+                QUERY PLAN                
+------------------------------------------
+ Bitmap Heap Scan on test_bigm
+   Recheck Cond: (col1 =% 'a'::text)
+   ->  Bitmap Index Scan on test_bigm_idx
+         Index Cond: (col1 =% 'a'::text)
+(4 rows)
+
+EXPLAIN (COSTS off) SELECT * FROM test_bigm WHERE col1 =% 'am';
+                QUERY PLAN                
+------------------------------------------
+ Bitmap Heap Scan on test_bigm
+   Recheck Cond: (col1 =% 'am'::text)
+   ->  Bitmap Index Scan on test_bigm_idx
+         Index Cond: (col1 =% 'am'::text)
+(4 rows)
+
+EXPLAIN (COSTS off) SELECT * FROM test_bigm WHERE col1 =% 'XML';
+                QUERY PLAN                 
+-------------------------------------------
+ Bitmap Heap Scan on test_bigm
+   Recheck Cond: (col1 =% 'XML'::text)
+   ->  Bitmap Index Scan on test_bigm_idx
+         Index Cond: (col1 =% 'XML'::text)
+(4 rows)
+
+EXPLAIN (COSTS off) SELECT * FROM test_bigm WHERE col1 =% 'bigm';
+                 QUERY PLAN                 
+--------------------------------------------
+ Bitmap Heap Scan on test_bigm
+   Recheck Cond: (col1 =% 'bigm'::text)
+   ->  Bitmap Index Scan on test_bigm_idx
+         Index Cond: (col1 =% 'bigm'::text)
+(4 rows)
+
+SELECT col1 FROM test_bigm WHERE col1 =% NULL;
+ col1 
+------
+(0 rows)
+
+SELECT col1 FROM test_bigm WHERE col1 =% '';
+ col1 
+------
+(0 rows)
+
+SELECT col1 FROM test_bigm WHERE col1 =% '%';
+                          col1                          
+--------------------------------------------------------
+ Sets the similarity threshold used by the =% operator.
+(1 row)
+
+SELECT col1 FROM test_bigm WHERE col1 =% '\\';
+                   col1                    
+-------------------------------------------
+ \dx displays list of installed extensions
+(1 row)
+
+SELECT col1 FROM test_bigm WHERE col1 =% '_';
+ col1 
+------
+(0 rows)
+
+SELECT col1 FROM test_bigm WHERE col1 =% '\\dx';
+                             col1                             
+--------------------------------------------------------------
+ Shows the maximum number of index keys.
+ Recheck that heap tuples fetched from index match the query.
+ \dx displays list of installed extensions
+(3 rows)
+
+SELECT col1 FROM test_bigm WHERE col1 =% '200%';
+                             col1                              
+---------------------------------------------------------------
+ Sets the similarity threshold used by the =% operator.
+ pg_bigm has improved the full text search performance by 200%
+(2 rows)
+
+SELECT col1 FROM test_bigm WHERE col1 =% '  ';
+ col1 
+------
+(0 rows)
+
+SELECT count(*), min(bigm_similarity(col1, 'Y')) FROM test_bigm WHERE col1 =% 'Y';
+ count |    min    
+-------+-----------
+     1 | 0.0212766
+(1 row)
+
+SELECT count(*), max(bigm_similarity(col1, 'Y')) FROM test_bigm WHERE NOT col1 =% 'Y';
+ count |    max    
+-------+-----------
+   248 | 0.0192308
+(1 row)
+
+SELECT count(*), min(bigm_similarity(col1, 'pi')) FROM test_bigm WHERE col1 =% 'pi';
+ count | min  
+-------+------
+    52 | 0.02
+(1 row)
+
+SELECT count(*), max(bigm_similarity(col1, 'pi')) FROM test_bigm WHERE NOT col1 =% 'pi';
+ count |    max    
+-------+-----------
+   197 | 0.0196078
+(1 row)
+
+SET pg_bigm.similarity_limit = 0.06;
+SELECT count(*), min(bigm_similarity(col1, 'GIN')) FROM test_bigm WHERE col1 =% 'GIN';
+ count |    min    
+-------+-----------
+     1 | 0.0769231
+(1 row)
+
+SELECT count(*), max(bigm_similarity(col1, 'GIN')) FROM test_bigm WHERE NOT col1 =% 'GIN';
+ count |    max    
+-------+-----------
+   248 | 0.0571429
+(1 row)
+
+SELECT count(*), min(bigm_similarity(col1, 'gin')) FROM test_bigm WHERE col1 =% 'gin';
+ count |    min    
+-------+-----------
+     5 | 0.0606061
+(1 row)
+
+SELECT count(*), max(bigm_similarity(col1, 'gin')) FROM test_bigm WHERE NOT col1 =% 'gin';
+ count |    max    
+-------+-----------
+   244 | 0.0588235
+(1 row)
+
+SELECT count(*), min(bigm_similarity(col1, 'Tool')) FROM test_bigm WHERE col1 =% 'Tool';
+ count |    min    
+-------+-----------
+     3 | 0.0645161
+(1 row)
+
+SELECT count(*), max(bigm_similarity(col1, 'Tool')) FROM test_bigm WHERE NOT col1 =% 'Tool';
+ count |    max    
+-------+-----------
+   246 | 0.0555556
+(1 row)
+
+SELECT count(*), min(bigm_similarity(col1, 'performance')) FROM test_bigm WHERE col1 =% 'performance';
+ count | min  
+-------+------
+   153 | 0.06
+(1 row)
+
+SELECT count(*), max(bigm_similarity(col1, 'performance')) FROM test_bigm WHERE NOT col1 =% 'performance';
+ count |    max    
+-------+-----------
+    96 | 0.0588235
+(1 row)
+
+-- tests for drop of pg_bigm
+DROP EXTENSION pg_bigm CASCADE;
+NOTICE:  drop cascades to index test_bigm_idx
+SELECT likequery('test');
+ERROR:  function likequery(unknown) does not exist
+LINE 1: SELECT likequery('test');
+               ^
+DETAIL:  There is no function of that name.

--- a/expected/pg_bigm_ja_2.out
+++ b/expected/pg_bigm_ja_2.out
@@ -1,0 +1,279 @@
+CREATE EXTENSION pg_bigm;
+\pset null '(null)'
+SET standard_conforming_strings = on;
+SET escape_string_warning = off;
+ERROR:  unrecognized configuration parameter "escape_string_warning"
+SET enable_seqscan = off;
+SET pg_bigm.enable_recheck = on;
+SET pg_bigm.gin_key_limit = 0;
+SET pg_bigm.similarity_limit = 0.02;
+-- reduce noise
+SET extra_float_digits TO 0;
+-- tests for likequery
+SELECT likequery('ポスグレの全文検索');
+      likequery       
+----------------------
+ %ポスグレの全文検索%
+(1 row)
+
+SELECT likequery('pg_bigmは検索性能を200%向上させました');
+                 likequery                 
+-------------------------------------------
+ %pg\_bigmは検索性能を200\%向上させました%
+(1 row)
+
+-- tests for show_bigm
+SELECT show_bigm('木');
+   show_bigm   
+---------------
+ {"木 "," 木"}
+(1 row)
+
+SELECT show_bigm('検索');
+     show_bigm      
+--------------------
+ {検索,"索 "," 検"}
+(1 row)
+
+SELECT show_bigm('インデックスを作成');
+                       show_bigm                       
+-------------------------------------------------------
+ {を作,イン,クス,スを,ック,デッ,ンデ,作成,"成 "," イ"}
+(1 row)
+
+SELECT show_bigm('pg_bigmは検索性能を200%向上させました');
+                                                 show_bigm                                                  
+------------------------------------------------------------------------------------------------------------
+ {させ,した,せま,"た ",は検,まし,を2,上さ,向上,性能,検索,索性,能を," p",%向,0%,00,20,_b,bi,g_,gm,ig,mは,pg}
+(1 row)
+
+-- tests for creation of full-text search index
+CREATE INDEX test_bigm_idx ON test_bigm USING gin (col1 gin_bigm_ops);
+\copy test_bigm(col1) from 'data/bigm_ja.csv' with csv
+EXPLAIN (COSTS off) SELECT col1 FROM test_bigm WHERE col1 LIKE likequery ('値');
+                 QUERY PLAN                 
+--------------------------------------------
+ Bitmap Heap Scan on test_bigm
+   Recheck Cond: (col1 ~~ '%値%'::text)
+   ->  Bitmap Index Scan on test_bigm_idx
+         Index Cond: (col1 ~~ '%値%'::text)
+(4 rows)
+
+EXPLAIN (COSTS off) SELECT col1 FROM test_bigm WHERE col1 LIKE likequery ('最大');
+                  QUERY PLAN                  
+----------------------------------------------
+ Bitmap Heap Scan on test_bigm
+   Recheck Cond: (col1 ~~ '%最大%'::text)
+   ->  Bitmap Index Scan on test_bigm_idx
+         Index Cond: (col1 ~~ '%最大%'::text)
+(4 rows)
+
+EXPLAIN (COSTS off) SELECT col1 FROM test_bigm WHERE col1 LIKE likequery ('ツール');
+                   QUERY PLAN                   
+------------------------------------------------
+ Bitmap Heap Scan on test_bigm
+   Recheck Cond: (col1 ~~ '%ツール%'::text)
+   ->  Bitmap Index Scan on test_bigm_idx
+         Index Cond: (col1 ~~ '%ツール%'::text)
+(4 rows)
+
+EXPLAIN (COSTS off) SELECT col1 FROM test_bigm WHERE col1 LIKE likequery ('全文検索');
+                    QUERY PLAN                    
+--------------------------------------------------
+ Bitmap Heap Scan on test_bigm
+   Recheck Cond: (col1 ~~ '%全文検索%'::text)
+   ->  Bitmap Index Scan on test_bigm_idx
+         Index Cond: (col1 ~~ '%全文検索%'::text)
+(4 rows)
+
+SELECT col1 FROM test_bigm WHERE col1 LIKE likequery ('値');
+                                col1                                
+--------------------------------------------------------------------
+ 設定値が0(デフォルト値)の場合は、検索文字列のすべての
+ (スーパーユーザに限らずどのユーザからでも)で設定値を変更できます。
+ 引数1がNULLの場合、戻り値はNULLです。
+(3 rows)
+
+SELECT col1 FROM test_bigm WHERE col1 LIKE likequery ('最大');
+                                  col1                                  
+------------------------------------------------------------------------
+ 最大で何個を全文検索インデックスの検索に使うか指定するパラメータです。
+ 2-gram文字列の最大数を制限することで、
+(2 rows)
+
+SELECT col1 FROM test_bigm WHERE col1 LIKE likequery ('ツール');
+                              col1                              
+----------------------------------------------------------------
+ pg_trgm - PostgreSQLで3-gramの全文検索を使えるようにするツール
+ pg_bigm - PostgreSQLで2-gramの全文検索を使えるようにするツール
+(2 rows)
+
+SELECT col1 FROM test_bigm WHERE col1 LIKE likequery ('インデックスを作成');
+                             col1                              
+---------------------------------------------------------------
+ GINインデックスを利用して全文検索用のインデックスを作成します
+(1 row)
+
+SELECT col1 FROM test_bigm WHERE col1 LIKE likequery ('3-gramの全文検索');
+                              col1                              
+----------------------------------------------------------------
+ pg_trgm - PostgreSQLで3-gramの全文検索を使えるようにするツール
+(1 row)
+
+-- check that the search results don't change if enable_recheck is disabled
+-- in order to check that index full search is NOT executed
+SET pg_bigm.enable_recheck = off;
+SELECT col1 FROM test_bigm WHERE col1 LIKE likequery ('値');
+                                col1                                
+--------------------------------------------------------------------
+ 設定値が0(デフォルト値)の場合は、検索文字列のすべての
+ (スーパーユーザに限らずどのユーザからでも)で設定値を変更できます。
+ 引数1がNULLの場合、戻り値はNULLです。
+(3 rows)
+
+SELECT col1 FROM test_bigm WHERE col1 LIKE likequery ('最大');
+                                  col1                                  
+------------------------------------------------------------------------
+ 最大で何個を全文検索インデックスの検索に使うか指定するパラメータです。
+ 2-gram文字列の最大数を制限することで、
+(2 rows)
+
+SET pg_bigm.enable_recheck = on;
+SELECT col1 FROM test_bigm WHERE col1 LIKE '%最大%';
+                                  col1                                  
+------------------------------------------------------------------------
+ 最大で何個を全文検索インデックスの検索に使うか指定するパラメータです。
+ 2-gram文字列の最大数を制限することで、
+(2 rows)
+
+-- tests for pg_bigm.enable_recheck
+SELECT col1 FROM test_bigm WHERE col1 LIKE likequery('東京都');
+     col1     
+--------------
+ ここは東京都
+(1 row)
+
+SET pg_bigm.enable_recheck = off;
+SELECT col1 FROM test_bigm WHERE col1 LIKE likequery('東京都');
+       col1       
+------------------
+ ここは東京都
+ 東京と京都に行く
+(2 rows)
+
+SELECT bigm_similarity('東京都', ' 東京都 ');
+ bigm_similarity 
+-----------------
+               1
+(1 row)
+
+SELECT bigm_similarity('東京都', '東京と京都');
+ bigm_similarity 
+-----------------
+        0.666667
+(1 row)
+
+SELECT bigm_similarity('東京と京都', '東京都');
+ bigm_similarity 
+-----------------
+        0.666667
+(1 row)
+
+SET pg_bigm.enable_recheck = on;
+-- tests for text similarity search
+EXPLAIN (COSTS off) SELECT col1 FROM test_bigm WHERE col1 =% '値';
+                QUERY PLAN                
+------------------------------------------
+ Bitmap Heap Scan on test_bigm
+   Recheck Cond: (col1 =% '値'::text)
+   ->  Bitmap Index Scan on test_bigm_idx
+         Index Cond: (col1 =% '値'::text)
+(4 rows)
+
+EXPLAIN (COSTS off) SELECT col1 FROM test_bigm WHERE col1 =% '最大';
+                 QUERY PLAN                 
+--------------------------------------------
+ Bitmap Heap Scan on test_bigm
+   Recheck Cond: (col1 =% '最大'::text)
+   ->  Bitmap Index Scan on test_bigm_idx
+         Index Cond: (col1 =% '最大'::text)
+(4 rows)
+
+EXPLAIN (COSTS off) SELECT col1 FROM test_bigm WHERE col1 =% 'ツール';
+                  QUERY PLAN                  
+----------------------------------------------
+ Bitmap Heap Scan on test_bigm
+   Recheck Cond: (col1 =% 'ツール'::text)
+   ->  Bitmap Index Scan on test_bigm_idx
+         Index Cond: (col1 =% 'ツール'::text)
+(4 rows)
+
+EXPLAIN (COSTS off) SELECT col1 FROM test_bigm WHERE col1 =% '全文検索';
+                   QUERY PLAN                   
+------------------------------------------------
+ Bitmap Heap Scan on test_bigm
+   Recheck Cond: (col1 =% '全文検索'::text)
+   ->  Bitmap Index Scan on test_bigm_idx
+         Index Cond: (col1 =% '全文検索'::text)
+(4 rows)
+
+SELECT count(*), min(bigm_similarity(col1, '値')) FROM test_bigm WHERE col1 =% '値';
+ count |  min   
+-------+--------
+     0 | (null)
+(1 row)
+
+SELECT count(*), max(bigm_similarity(col1, '値')) FROM test_bigm WHERE NOT col1 =% '値';
+ count | max 
+-------+-----
+   278 |   0
+(1 row)
+
+SELECT count(*), min(bigm_similarity(col1, '最大')) FROM test_bigm WHERE col1 =% '最大';
+ count |    min    
+-------+-----------
+     2 | 0.0434783
+(1 row)
+
+SELECT count(*), max(bigm_similarity(col1, '最大')) FROM test_bigm WHERE NOT col1 =% '最大';
+ count | max 
+-------+-----
+   276 |   0
+(1 row)
+
+SELECT count(*), min(bigm_similarity(col1, 'ツール')) FROM test_bigm WHERE col1 =% 'ツール';
+ count |    min    
+-------+-----------
+     2 | 0.0681818
+(1 row)
+
+SELECT count(*), max(bigm_similarity(col1, 'ツール')) FROM test_bigm WHERE NOT col1 =% 'ツール';
+ count | max 
+-------+-----
+   276 |   0
+(1 row)
+
+SELECT count(*), min(bigm_similarity(col1, 'インデックスを作成')) FROM test_bigm WHERE col1 =% 'インデックスを作成';
+ count |  min  
+-------+-------
+     9 | 0.125
+(1 row)
+
+SELECT count(*), max(bigm_similarity(col1, 'インデックスを作成')) FROM test_bigm WHERE NOT col1 =% 'インデックスを作成';
+ count | max 
+-------+-----
+   269 |   0
+(1 row)
+
+SELECT count(*), min(bigm_similarity(col1, '3-gramの全文検索')) FROM test_bigm WHERE col1 =% '3-gramの全文検索';
+ count | min  
+-------+------
+    75 | 0.02
+(1 row)
+
+SELECT count(*), max(bigm_similarity(col1, '3-gramの全文検索')) FROM test_bigm WHERE NOT col1 =% '3-gramの全文検索';
+ count |    max    
+-------+-----------
+   203 | 0.0196078
+(1 row)
+


### PR DESCRIPTION
PG19 made two changes that broke pg_bigm's existing PG18 fallback for
t_isspace() (originally added in commit which copied the PG17
implementation after PG18 removed t_isspace via core commit d3aad4ac57c - https://github.com/postgres/postgres/commit/d3aad4ac57c5592ade77916404e6d8a989a1d6a1):

  - the database_ctype_is_c global flag is gone; the equivalent
    information now lives on pg_locale_t->ctype_is_c, retrievable
    via pg_database_locale().
  - char2wchar() is no longer exported from utils/pg_locale.h
    (it was made static in src/backend/utils/adt/pg_locale_libc.c).

Add a PG_VERSION_NUM >= 190000 branch to t_isspace() that uses the new
public API: pg_database_locale() for the locale, pg_mb2wchar_with_len()
to decode the multibyte character, and pg_iswspace() for the classify
call. This mirrors the pattern PG19 itself uses in
src/backend/tsearch/ts_locale.c for t_isalnum / t_isalpha. The PG18
code path is preserved unchanged.

Also add alternate expected outputs (expected/pg_bigm_2.out,
expected/pg_bigm_ja_2.out) so the regression suite passes on PG19,
where:

  - escape_string_warning was removed (SET errors out).
  - standard_conforming_strings can no longer be turned off
    (SET errors out, and the dependent \\-escape tests behave
    differently under standard strings).
  - the "function does not exist" error switched its trailing
    line from HINT to DETAIL with a new message.

The original expected files are kept, so PG <= 18 continues to pass.